### PR TITLE
fix bambu ac_channel constructor

### DIFF
--- a/hls4ml/templates/bambu/ac_types/ac_channel.h
+++ b/hls4ml/templates/bambu/ac_types/ac_channel.h
@@ -868,11 +868,10 @@ ac_channel<T>::ac_channel(const char* bin_file)
 {
    std::ifstream init_file(bin_file, std::ifstream::in | std::ifstream::binary);
    T v;
-   while(chan.num_free())
+   while (init_file.read((char*)&v, sizeof(T))) 
    {
-      init_file.read((char*)&v, sizeof(T));
-      write(v);
-   }
+   	write(v);
+   } 
 }
 
 template <class T>


### PR DESCRIPTION
# Fix ac_channel constructor for io_stream

> :memo: 
> Fix a bug encountered when running tests with io_stream

## Bug fix
This PR fixes a problem with ac_channel constructor in template/bambu/ac_types.
The ac_channel constructor incorrectly handled binary files that are not used during Python inference of an HLS model.
This led to improper memory allocation.

- [x] Bug fix (non-breaking change that fixes an issue)

