### PR TITLE
Make pixels vector of ap_uint initialisation explicit 

### DIFF
--- a/hls4ml/backends/bambu/passes/convolution_templates.py
+++ b/hls4ml/backends/bambu/passes/convolution_templates.py
@@ -479,7 +479,9 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['index'] = str(node.index) + '_pointwise'
         params['weight_t'] = node.get_weights('pointwise').type
         params['min_width'] = params['in_width']
-        params['instructions'] = '0'
+        # explicit constructor for pointwise
+        index_token = params['index']
+        params['instructions'] = f"ap_uint<config{index_token}::filt_width>(0)"
         if node.model.config.get_config_value('IOType') == 'io_parallel':
             namespace = params['namespace']
             params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_pw'
@@ -622,7 +624,9 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         params['weight_t'] = node.get_weights('pointwise').type
         params['min_height'] = params['in_height']
         params['min_width'] = params['in_width']
-        params['instructions'] = '0'
+        # explicit constructor for pointwise
+        index_token = params['index']
+        params['instructions'] = f"ap_uint<config{index_token}::filt_height * config{index_token}::filt_width>(0)"
         if node.model.config.get_config_value('IOType') == 'io_parallel':
             namespace = params['namespace']
             params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_pw'

--- a/test/pytest/test_auto_precision.py
+++ b/test/pytest/test_auto_precision.py
@@ -119,7 +119,7 @@ def keras_model_sepconv2d():
 
 
 @pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus'])
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Bambu'])
 @pytest.mark.parametrize('model_type', ['conv1d', 'conv2d'])
 def test_auto_precision_conv(keras_model_conv1d, keras_model_conv2d, data_2d, data_3d, model_type, io_type, backend):
     if model_type == 'conv1d':


### PR DESCRIPTION
Updated initialisation of pixels vector in all 1D and 2D convolution templates explicitly, by explicitly constructing the sequences of ap_uint since it requires an explicit constructor. Added Bambu as a backend in the related test. 