### PR TITLE
Changed build() to be more bambu-specific and convenient for the user

### DIFF
--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -310,7 +310,7 @@ class BambuBackend(FPGABackend):
         run_kwargs=None,
         parse_report=True,
     ):
-        """Run Bambu HLS on given model with default arguments to make HLS4ML compatible.
+        """Run Bambu HLS on given model, adding some default arguments for compatability
 
         Args:
             model (ModelGraph): Model to be built with Bambu.
@@ -335,11 +335,12 @@ class BambuBackend(FPGABackend):
                     args=['--simulate', '--clock-period=5']
                 )
 
-            Capture output for inspection::
+            Capture output for inspection and emit LLVM representation:
 
                 result = model.build(
                     args=['--simulate', '--print-dot'],
-                    capture_output=True
+                    capture_output=True,
+                    debug_IR=True
                 )
                 print(result['stdout'])
         """
@@ -355,7 +356,7 @@ class BambuBackend(FPGABackend):
         REQ_ARGS      = ['-lm', 
                          '-Ifirmware/ac_types',
                         ]
-        DEBUG_IR_ARGS = ['--extra-gcc-options="-emit-llvm -S"', 
+        DEBUG_IR_ARGS = ['--extra-gcc-options=-emit-llvm -S', 
                            '--no-clean'
                         ]
 

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -300,28 +300,25 @@ class BambuBackend(FPGABackend):
     def build(
         self,
         model,
-        command=None,
         args=None,
         *,
         capture_output=False,
+        debug_IR=False,
         check=False,
         dry_run=False,
-        cwd=None,
         env=None,
         run_kwargs=None,
         parse_report=True,
     ):
-        """Forward arbitrary commands to the ``bambu`` executable.
+        """Run Bambu HLS on given model with default arguments to make HLS4ML compatible.
 
         Args:
             model (ModelGraph): Model to be built with Bambu.
-            command (str | Sequence[str] | None): Complete command string or token sequence.
-                When omitted, ``args`` must be provided.
-            args (str | Sequence[str] | None): Arguments appended to ``bambu`` if ``command`` is not given.
+            args (str | Sequence[str] | None): Arguments appended to default Bambu command for this model.
             capture_output (bool): If ``True``, capture ``stdout``/``stderr`` and return them.
+            debug_IR (bool): If ``True``, keep intermediate files produced by Bambu and emit LLVM representation.
             check (bool): If ``True``, raise ``CalledProcessError`` when the command fails.
             dry_run (bool): If ``True``, return the resolved command without executing it.
-            cwd (str | None): Working directory for the command. Defaults to the model output directory.
             env (Mapping[str, str] | None): Environment overrides applied to the subprocess.
             run_kwargs (dict | None): Additional keyword arguments forwarded to ``subprocess.run``.
             parse_report (bool): If ``True``, parse any ``bambu_results_*.xml`` files in the working directory.
@@ -332,45 +329,44 @@ class BambuBackend(FPGABackend):
             the parsed XML contents are returned under the ``report`` key.
 
         Examples:
-            Basic usage with a command string::
+            Basic usage with added args:
 
                 result = model.build(
-                    command='firmware/myproject.cpp --simulate --clock-period=5'
-                )
-
-            Using args parameter (``bambu`` executable is automatically prepended)::
-
-                result = model.build(
-                    args=['firmware/myproject.cpp', '--simulate', '--clock-period=5']
+                    args=['--simulate', '--clock-period=5']
                 )
 
             Capture output for inspection::
 
                 result = model.build(
-                    args=['firmware/myproject.cpp', '--simulate'],
+                    args=['--simulate', '--print-dot'],
                     capture_output=True
                 )
                 print(result['stdout'])
         """
 
-        if run_kwargs is None:
-            run_kwargs = {}
-        if not isinstance(run_kwargs, dict):
-            raise TypeError('run_kwargs must be a mapping')
+        project_name = model.config.get_project_name()
+        project_dir = model.config.get_output_dir()
 
-        if command is not None or args is not None:
-            command_tokens = self._normalize_bambu_command(command, args)
-        else:
-            raise ValueError('No Bambu command specified. Provide "command" or "args".')
+        # Bambu-specific command/flags
+        BASE_COMMAND  = ['bambu', 
+                         os.path.join('firmware', f'{project_name}.cpp'), 
+                         f'--top-fname={project_name}'
+                        ]
+        REQ_ARGS      = ['-lm', 
+                         '-Ifirmware/ac_types',
+                        ]
+        DEBUG_IR_ARGS = ['--extra-gcc-options="-emit-llvm -S"', 
+                           '--no-clean'
+                        ]
 
-        target_cwd = cwd or model.config.get_output_dir()
-        if target_cwd is None:
-            target_cwd = os.getcwd()
-        if not os.path.isdir(target_cwd):
-            raise FileNotFoundError(f'Working directory "{target_cwd}" does not exist.')
+        # Build user's custom command with Bambu defaults
+        command_tokens = BASE_COMMAND + REQ_ARGS
 
-        if not dry_run:
-            self._ensure_bambu_available()
+        if args is not None:
+            command_tokens += self._normalize_bambu_command(args)
+
+        if debug_IR:
+            command_tokens += DEBUG_IR_ARGS
 
         command_str = ' '.join(shlex.quote(str(token)) for token in command_tokens)
 
@@ -378,11 +374,14 @@ class BambuBackend(FPGABackend):
             return {
                 'command': command_tokens,
                 'command_str': command_str,
-                'cwd': target_cwd,
+                'cwd': project_dir,
                 'dry_run': True,
-                'report': parse_bambu_report(target_cwd) if parse_report else None,
+                'report': parse_bambu_report(project_dir) if parse_report else None,
             }
+        else:
+            self._ensure_bambu_available()
 
+        # Alter os runtime environment
         run_env = os.environ.copy()
         if env is not None:
             if not hasattr(env, 'items'):
@@ -393,7 +392,11 @@ class BambuBackend(FPGABackend):
                 else:
                     run_env[str(key)] = str(value)
 
-        run_kwargs = dict(run_kwargs)
+        # Add optional runtime keyword arguments to subprocess
+        if run_kwargs is None:
+            run_kwargs = {}
+        if not isinstance(run_kwargs, dict):
+            raise TypeError('run_kwargs must be a mapping')
         if capture_output and any(stream in run_kwargs for stream in ('stdout', 'stderr')):
             raise ValueError('Cannot set stdout/stderr in run_kwargs when capture_output=True.')
         run_kwargs.setdefault('text', True)
@@ -402,18 +405,18 @@ class BambuBackend(FPGABackend):
 
         completed = subprocess.run(
             command_tokens,
-            cwd=target_cwd,
+            cwd=project_dir,
             env=run_env,
             check=check,
             **run_kwargs,
         )
 
-        report_data = parse_bambu_report(target_cwd) if parse_report else None
+        report_data = parse_bambu_report(project_dir) if parse_report else None
 
         result = {
             'command': command_tokens,
             'command_str': command_str,
-            'cwd': target_cwd,
+            'cwd': project_dir,
             'returncode': completed.returncode,
             'report': report_data,
         }
@@ -429,33 +432,16 @@ class BambuBackend(FPGABackend):
             raise EnvironmentError('Bambu HLS installation not found. Make sure "bambu" is on PATH.')
 
     @staticmethod
-    def _normalize_bambu_command(command, args=None):
-        if command is not None and args is not None:
-            raise ValueError('Specify only one of "command" or "args".')
-
-        if command is not None:
-            if isinstance(command, (list, tuple)):
-                tokens = [str(token) for token in command]
-            else:
-                command_str = str(command).strip()
-                if not command_str:
-                    raise ValueError('Command string is empty.')
-                tokens = shlex.split(command_str)
-        elif args is not None:
+    def _normalize_bambu_command(args):
+        if args is not None:
             if isinstance(args, (list, tuple)):
-                tokens = ['bambu'] + [str(token) for token in args]
+                tokens = [str(token) for token in args]
             elif isinstance(args, str):
-                tokens = ['bambu'] + shlex.split(args)
+                tokens = shlex.split(args)
             else:
                 raise TypeError('args must be a string or a sequence of strings.')
         else:
             tokens = []
-
-        if not tokens:
-            raise ValueError('Unable to derive Bambu command.')
-
-        if tokens[0] != 'bambu':
-            tokens.insert(0, 'bambu')
 
         return tokens
 

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -1,0 +1,204 @@
+import os
+import pytest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+
+import hls4ml
+
+# -----------------------------------------------------------------------------
+# fixtures: model + instance
+# -----------------------------------------------------------------------------
+
+@pytest.fixture
+def hls_model_setup(tmp_path):
+    """Fixture to create basic HLS model for Bambu backend"""
+    model = Sequential()
+    model.add(Dense(5, input_shape=(16,), name='fc1', activation='relu'))
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='model')
+
+    output_dir = str(tmp_path / f'hls4mlprj_build_bambu')
+
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        output_dir=output_dir,
+        backend="Bambu",
+    )
+
+    yield hls_model
+
+
+@pytest.fixture
+def fake_completed_process():
+    """Fixture that returns a fake subprocess result."""
+    return SimpleNamespace(
+        returncode=0
+    )
+
+# -----------------------------------------------------------------------------
+# helpers
+# -----------------------------------------------------------------------------
+
+def patch_subprocess(monkeypatch, completed):
+    run = Mock(return_value=completed)
+    monkeypatch.setattr("subprocess.run", run)
+    return run
+
+
+def patch_bambu_available(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/bambu")
+
+
+def patch_bambu_unavailable(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+# -----------------------------------------------------------------------------
+# tests
+# -----------------------------------------------------------------------------
+
+ARGS = {
+    "empty_str": {
+        "input": "", 
+        "expected": []
+        },
+    "none": {
+        "input": None, 
+        "expected": []
+        },
+    "empty_list": {
+        "input": [], 
+        "expected": []
+        },
+    "empty_tuple": {
+        "input": (), 
+        "expected": []
+        },
+    "string_with_single_quotes": {
+        "input": "--extra-gcc-options='-emit-llvm -S'", 
+        "expected": ["--extra-gcc-options=-emit-llvm -S"]
+        },
+    "string_with_double_quotes": {
+        "input": '--extra-gcc-options="-emit-llvm -S"', 
+        "expected": ["--extra-gcc-options=-emit-llvm -S"]
+        },
+    "list_args": {
+        "input": ['--simulate', '--print-dot'], 
+        "expected": ['--simulate', '--print-dot']
+        },
+    "tuple_args": {
+        "input": ('--simulate', '--print-dot'), 
+        "expected": ['--simulate', '--print-dot']
+        },
+}
+
+@pytest.mark.parametrize("case", ARGS.values(), ids=ARGS.keys())
+def test_args_normalization(case, hls_model_setup):
+    """Test that user arguments are normalized and appended correctly to the default Bambu command."""
+    args = case["input"]
+    expected = case["expected"]
+
+    model = hls_model_setup
+    results = model.build(args=args, dry_run=True)
+
+    # Defaults
+    BASE_COMMAND = ['bambu', os.path.join('firmware', f'{model.config.get_project_name()}.cpp'),
+                    f'--top-fname={model.config.get_project_name()}']
+    
+    # Current flags needed for HLS4ML and Bambu compatability
+    # Likely to change as Bambu updates
+    REQ_ARGS = ['-lm', '-Ifirmware/ac_types']
+
+    # First check default command
+    assert results["command"][:len(BASE_COMMAND)] == BASE_COMMAND
+
+    # Then check that required AND user args are appended
+    for token in (REQ_ARGS + expected):
+        assert token in results["command"][len(BASE_COMMAND):]
+
+
+def test_debug_IR_flag(hls_model_setup):
+    """Test that the debug_IR flag appends the correct Bambu debug arguments."""
+    model = hls_model_setup
+    results = model.build(debug_IR=True, dry_run=True)
+
+    # Debug IR args appended
+    DEBUG_IR_ARGS = ['--extra-gcc-options=-emit-llvm -S', '--no-clean']
+    assert all(arg in results["command"] for arg in DEBUG_IR_ARGS)
+
+    # Debug IR off
+    results2 = model.build(debug_IR=False, dry_run=True)
+    assert not any(arg in results2["command"] for arg in DEBUG_IR_ARGS)
+
+
+def test_exceptions(hls_model_setup):
+    """Test that invalid arguments to build() raise the correct exceptions."""
+    model = hls_model_setup
+
+    # args must be list, tuple, or string
+    with pytest.raises(TypeError):
+        model.build(args=0)
+
+    # env must be mapping
+    with pytest.raises(TypeError):
+        model.build(env="not_a_dict")
+
+    # run_kwargs must be mapping
+    with pytest.raises(TypeError):
+        model.build(run_kwargs="not_a_dict")
+
+    # capture_output + stdout/stderr in run_kwargs
+    with pytest.raises(ValueError):
+        model.build(capture_output=True, run_kwargs={'stdout': None})
+
+
+@pytest.mark.parametrize(
+    "env, expected_present, expected_missing",
+    [
+        ({"FOO": "1"}, ["FOO"], []),
+        ({"FOO": None}, [], ["FOO"]),
+    ],
+)
+def test_env_handling(
+    monkeypatch,
+    hls_model_setup,
+    fake_completed_process,
+    env,
+    expected_present,
+    expected_missing,
+):
+    """Test that the environment passed to subprocess.run is correctly modified according to `env`."""
+    patch_bambu_available(monkeypatch)
+    run = patch_subprocess(monkeypatch, fake_completed_process)
+
+    model = hls_model_setup
+    model.build(env=env)
+
+    _, kwargs = run.call_args
+    run_env = kwargs["env"]
+
+    # added env variables
+    for key in expected_present:
+        assert key in run_env
+
+    # deleted env variables
+    for key in expected_missing:
+        assert key not in run_env
+
+    # make sure rest of environment unaffected
+    for key, value in os.environ.items():
+        if key not in env or env[key] is None:
+            assert run_env[key] == value
+
+
+def test_bambu_missing_raises(hls_model_setup, monkeypatch):
+    """Test that build() raises an EnvironmentError if Bambu is not found on PATH."""
+    patch_bambu_unavailable(monkeypatch)
+
+    model = hls_model_setup
+
+    with pytest.raises(EnvironmentError):
+        model.build()


### PR DESCRIPTION
# Description

> :memo: Please include a summary of the change.

Changed build() function in bambu_backend to be more bambu-specific (i.e., use project name/directory automatically, append arguments that are necessary for latest version of bambu to work with HLS4ML). Also added a Intermediate Representation debug option for developers which leaves Bambu's IR in the project directory.

## Type of change

- [x] Other (Convenience added to function)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.

Created and ran the Pytest: test_build_bambu.py
