### PR TITLE
fastmachinelearning/hls4ml PR #1417 fixes

### DIFF
--- a/test/pytest/test_clone_flatten.py
+++ b/test/pytest/test_clone_flatten.py
@@ -27,9 +27,8 @@ def keras_model():
 
 
 @pytest.fixture
-@pytest.mark.parametrize('io_type', ['io_stream'])
-@pytest.mark.parametrize('backend', ['Vivado', 'Quartus', 'Catapult'])
-def hls_model(keras_model, backend, io_type):
+def hls_model(keras_model, request):
+    io_type, backend = request.param
     hls_config = hls4ml.utils.config_from_keras_model(
         keras_model, default_precision='ap_int<6>', granularity='name', backend=backend
     )
@@ -46,8 +45,12 @@ def hls_model(keras_model, backend, io_type):
     return hls_model
 
 
-@pytest.mark.parametrize('io_type', ['io_stream'])
-@pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
+@pytest.mark.parametrize(
+    'hls_model',
+    [('io_stream', 'Vivado'), ('io_stream', 'Quartus')],
+    indirect=True,
+    ids=['io_stream_Vivado', 'io_stream_Quartus'],
+)
 def test_accuracy(data, keras_model, hls_model):
     X = data
     model = keras_model

--- a/test/pytest/test_cnn_mnist_qkeras.py
+++ b/test/pytest/test_cnn_mnist_qkeras.py
@@ -41,22 +41,8 @@ def mnist_model():
 
 
 @pytest.fixture
-@pytest.mark.parametrize(
-    'backend,io_type,strategy',
-    [
-        ('Quartus', 'io_parallel', 'resource'),
-        ('Quartus', 'io_stream', 'resource'),
-        ('Vivado', 'io_parallel', 'resource'),
-        ('Vivado', 'io_parallel', 'latency'),
-        ('Vivado', 'io_stream', 'latency'),
-        ('Vivado', 'io_stream', 'resource'),
-        ('Vitis', 'io_parallel', 'resource'),
-        ('Vitis', 'io_parallel', 'latency'),
-        ('Vitis', 'io_stream', 'latency'),
-        ('Vitis', 'io_stream', 'resource'),
-    ],
-)
-def hls_model(mnist_model, backend, io_type, strategy):
+def hls_model(mnist_model, request):
+    backend, io_type, strategy = request.param
     keras_model = mnist_model
     hls_config = hls4ml.utils.config_from_keras_model(keras_model, granularity='name', backend=backend)
     hls_config['Model']['Strategy'] = strategy
@@ -72,7 +58,7 @@ def hls_model(mnist_model, backend, io_type, strategy):
 
 
 @pytest.mark.parametrize(
-    'backend,io_type,strategy',
+    'hls_model',
     [
         ('Quartus', 'io_parallel', 'resource'),
         ('Quartus', 'io_stream', 'resource'),
@@ -84,6 +70,19 @@ def hls_model(mnist_model, backend, io_type, strategy):
         ('Vitis', 'io_parallel', 'latency'),
         ('Vitis', 'io_stream', 'latency'),
         ('Vitis', 'io_stream', 'resource'),
+    ],
+    indirect=True,
+    ids=[
+        'Quartus_io_parallel_resource',
+        'Quartus_io_stream_resource',
+        'Vivado_io_parallel_resource',
+        'Vivado_io_parallel_latency',
+        'Vivado_io_stream_latency',
+        'Vivado_io_stream_resource',
+        'Vitis_io_parallel_resource',
+        'Vitis_io_parallel_latency',
+        'Vitis_io_stream_latency',
+        'Vitis_io_stream_resource',
     ],
 )
 def test_accuracy(mnist_data, mnist_model, hls_model):

--- a/test/pytest/test_conv1d.py
+++ b/test/pytest/test_conv1d.py
@@ -27,26 +27,8 @@ def keras_model():
 
 
 @pytest.fixture
-@pytest.mark.parametrize(
-    'backend,io_type,strategy',
-    [
-        ('Quartus', 'io_parallel', 'resource'),
-        ('Quartus', 'io_stream', 'resource'),
-        ('oneAPI', 'io_parallel', 'resource'),
-        ('oneAPI', 'io_stream', 'resource'),
-        ('Vivado', 'io_parallel', 'resource'),
-        ('Vivado', 'io_parallel', 'latency'),
-        ('Vivado', 'io_stream', 'latency'),
-        ('Vivado', 'io_stream', 'resource'),
-        ('Vitis', 'io_parallel', 'resource'),
-        ('Vitis', 'io_parallel', 'latency'),
-        ('Vitis', 'io_stream', 'latency'),
-        ('Vitis', 'io_stream', 'resource'),
-        ('Catapult', 'io_stream', 'latency'),
-        ('Catapult', 'io_stream', 'resource'),
-    ],
-)
-def hls_model(keras_model, backend, io_type, strategy):
+def hls_model(keras_model, request):
+    backend, io_type, strategy = request.param
     default_precision = (
         'ap_fixed<16,3,AP_RND_CONV,AP_SAT>' if backend == 'Vivado' else 'ac_fixed<16,3,true,AC_RND_CONV,AC_SAT>'
     )
@@ -82,7 +64,7 @@ def hls_model(keras_model, backend, io_type, strategy):
 
 
 @pytest.mark.parametrize(
-    'backend,io_type,strategy',
+    'hls_model',
     [
         ('Quartus', 'io_parallel', 'resource'),
         ('Quartus', 'io_stream', 'resource'),
@@ -98,6 +80,23 @@ def hls_model(keras_model, backend, io_type, strategy):
         ('Vitis', 'io_stream', 'resource'),
         ('Catapult', 'io_stream', 'latency'),
         ('Catapult', 'io_stream', 'resource'),
+    ],
+    indirect=True,
+    ids=[
+        'Quartus_io_parallel_resource',
+        'Quartus_io_stream_resource',
+        'oneAPI_io_parallel_resource',
+        'oneAPI_io_stream_resource',
+        'Vivado_io_parallel_resource',
+        'Vivado_io_parallel_latency',
+        'Vivado_io_stream_latency',
+        'Vivado_io_stream_resource',
+        'Vitis_io_parallel_resource',
+        'Vitis_io_parallel_latency',
+        'Vitis_io_stream_latency',
+        'Vitis_io_stream_resource',
+        'Catapult_io_stream_latency',
+        'Catapult_io_stream_resource',
     ],
 )
 def test_accuracy(data, keras_model, hls_model):

--- a/test/pytest/test_embed.py
+++ b/test/pytest/test_embed.py
@@ -25,9 +25,8 @@ def keras_model():
 
 
 @pytest.fixture
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult', 'oneAPI'])
-@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
-def hls_model(keras_model, backend, io_type):
+def hls_model(keras_model, request):
+    backend, io_type = request.param
     hls_config = hls4ml.utils.config_from_keras_model(
         keras_model, default_precision='ap_fixed<16,6>', granularity='name', backend=backend
     )
@@ -41,8 +40,34 @@ def hls_model(keras_model, backend, io_type):
     return hls_model
 
 
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult', 'oneAPI'])
-@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize(
+    'hls_model',
+    [
+        ('Vivado', 'io_parallel'),
+        ('Vitis', 'io_parallel'),
+        ('Quartus', 'io_parallel'),
+        ('Catapult', 'io_parallel'),
+        ('oneAPI', 'io_parallel'),
+        ('Vivado', 'io_stream'),
+        ('Vitis', 'io_stream'),
+        ('Quartus', 'io_stream'),
+        ('Catapult', 'io_stream'),
+        ('oneAPI', 'io_stream'),
+    ],
+    ids=[
+        'vivado_parallel',
+        'vitis_parallel',
+        'quartus_parallel',
+        'catapult_parallel',
+        'oneapi_parallel',
+        'vivado_stream',
+        'vitis_stream',
+        'quartus_stream',
+        'catapult_stream',
+        'oneapi_stream',
+    ],
+    indirect=True,
+)
 def test_embedding_accuracy(data, keras_model, hls_model):
     X = data
     model = keras_model

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -70,11 +70,12 @@ def load_jettagging_model():
 
 # TODO - Paramaterize for Quartus (different strategies?)
 @pytest.fixture
-@pytest.mark.parametrize('strategy', ['latency', 'resource'])
-def convert(load_jettagging_model, strategy):
+def convert(load_jettagging_model, request):
     """
     Convert a QKeras model trained on the jet tagging dataset
     """
+
+    strategy = request.param
     model = load_jettagging_model
 
     config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
@@ -91,8 +92,8 @@ def convert(load_jettagging_model, strategy):
     return hls_model
 
 
-@pytest.mark.parametrize('strategy', ['latency', 'resource'])
-def test_accuracy(convert, load_jettagging_model, get_jettagging_data, strategy):
+@pytest.mark.parametrize('convert', ['latency', 'resource'], indirect=True, ids=['latency', 'resource'])
+def test_accuracy(convert, load_jettagging_model, get_jettagging_data):
     """
     Test the hls4ml-evaluated accuracy of a 3 hidden layer QKeras model trained on
     the jet tagging dataset. QKeras model accuracy is required to be over 70%, and

--- a/test/pytest/test_transpose_concat.py
+++ b/test/pytest/test_transpose_concat.py
@@ -28,9 +28,8 @@ def keras_model():
 
 
 @pytest.fixture
-@pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
-def hls_model(keras_model, backend, io_type):
+def hls_model(keras_model, request):
+    io_type, backend = request.param
     hls_config = hls4ml.utils.config_from_keras_model(
         keras_model, default_precision='ap_fixed<16,3,AP_RND_CONV,AP_SAT>', granularity='name', backend=backend
     )
@@ -44,8 +43,30 @@ def hls_model(keras_model, backend, io_type):
     return hls_model
 
 
-@pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
+@pytest.mark.parametrize(
+    'hls_model',
+    [
+        ('io_stream', 'Vivado'),
+        ('io_stream', 'Vitis'),
+        ('io_stream', 'Quartus'),
+        ('io_stream', 'oneAPI'),
+        ('io_parallel', 'Vivado'),
+        ('io_parallel', 'Vitis'),
+        ('io_parallel', 'Quartus'),
+        ('io_parallel', 'oneAPI'),
+    ],
+    indirect=True,
+    ids=[
+        'vivado_stream',
+        'vitis_streamq',
+        'quartus_stream',
+        'oneapi_stream',
+        'vivado_parallel',
+        'vitis_parallel',
+        'quartus_parallel',
+        'oneapi_parallel',
+    ],
+)
 def test_accuracy(data, keras_model, hls_model):
     X = data
     model = keras_model


### PR DESCRIPTION
Quoting reply from [JanFSchulte](https://github.com/JanFSchulte) (PR: https://github.com/fastmachinelearning/hls4ml/pull/1417)

---

> As pointed out by @marco66colombo in #1412, pytest 9 enforces a rule that fixtures can't be parametrized. The way around that is indirect parametrization via the calling test function. This PR makes that change for all tests.
>
> Downsides:
> - Nested parametrizations are not supported this way, leading to a bit of overhead in declaring tests.
> - The tests are no longer named using the values of the parameters, so a test will no longer by called `test_embedding_accuracy[Catapult, io_parallel]` but rather `test_embedding_accuracy[hls_model3]` for example. This will make it more annoying to identify the failing test.
>
>
> ## Type of change
>
> - [x]  Bug fix (non-breaking change that fixes an issue)
>
> ## Tests
>
> Tested all affected test locally in an environment with pytest 9.
> ## Checklist
>
> - [x]  All