### PR TITLE
Update minimum C++ standard to C++14 in build_lib.sh

### DIFF
--- a/hls4ml/templates/bambu/build_lib.sh
+++ b/hls4ml/templates/bambu/build_lib.sh
@@ -8,7 +8,7 @@ CFLAGS="-O3 -fPIC"
 if echo "" | ${CC} -Werror -fsyntax-only -std=c++23 -xc++ - -o /dev/null &> /dev/null; then
   CFLAGS+=" -std=c++23"
 else
-  CFLAGS+=" -std=c++11"
+  CFLAGS+=" -std=c++14"
 fi
 
 # Include -fno-gnu-unique if it is there


### PR DESCRIPTION
This PR updates the minimum C++ standard from C++11 to C++14 in the build_lib.sh script. This change is necessary to support extended constexpr features required by ac_int.h. Currently, the build fails in C++11 because some constexpr functions (like float_floor) contain multiple statements or logic that exceed the C++11 single-return restriction.