### PR TITLE
Update Bambu backend for compatability

### DIFF
--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -434,7 +434,8 @@ class BambuBackend(FPGABackend):
                         '-Ifirmware/ac_types',
                         '--compiler=I386_CLANG16',
                         '--generate-interface=INFER',
-                        '-v4'
+                        '-v4',
+                        '-m64'
                        ]
         CMD_ARGS      = []
         
@@ -442,10 +443,9 @@ class BambuBackend(FPGABackend):
 
         ### RESET ###
         bambu_output_patterns = [
-            f"*{project_name}*.cache", f"*{project_name}*.hw", f"*{project_name}*.ip_user_files", 
-            ".Xil", "vivado_reports", "HLS_output", f"*{project_name}*.xpr", "bambu_results_*.xml", 
-            "clockInfo.txt", f"{project_name}-*_tb.exe", f"{project_name}.v", "results.txt",
-            "simulate*.sh", "synthesize*.sh"            
+            "HLS_output", "panda-temp", "vivado_reports", "bambu_results*.xml", 
+            "evaluate*.sh", "memory_allocation*.xml" f"{project_name}-*_tb.exe", 
+            f"{project_name}.v", "results.txt", "synthesize*.sh", "panda_libtech.v"        
             ]
         matches = [p for pat in bambu_output_patterns for p in Path(project_dir).glob(pat)]
         is_dirty_directory = any(matches)
@@ -632,7 +632,7 @@ class BambuBackend(FPGABackend):
         """Aggregate final reports in one directory based on Part Family/Software used"""
         if family == 'Xilinx':
             return(
-                'src_root="HLS_output/Synthesis/vivado_flow"\n'
+                'src_root="HLS_output/xilinx/flow_backend"\n'
                 'dst_root="vivado_reports"\n'
                 'mkdir -p "$dst_root"\n'
                 'find "$src_root" -type f \( -iname "*.rpt" -o -iname "*.xml" \) -exec cp -p {} "$dst_root"/ \;'

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -82,19 +82,20 @@ partname_to_bambu = {
     # : "xc6vlx240t-1ff1156", 
 
     # 7-series
-    "xc7a100tcsg324-1" : {"device_name" : "xc7a100t-1csg324-VVD", "family" : "Xilinx"}, # 7-series Artix! vsynth confirmed working, using as default for now
+    "xc7a100tcsg324-1" : {"device_name" : "xc7a100t-1csg324", "family" : "Xilinx"}, # 7-series Artix! vsynth confirmed working, using as default for now
     # : "xc7vx330t-1ffg1157",
-    # : "xc7vx485t-2ffg1761-VVD",
-    # : "xc7vx690t-3ffg1930-VVD", 
+    # : "xc7vx485t-2ffg1761",
+    # : "xc7vx690t-3ffg1930", 
     # : "xc7z020-1clg484",
-    # : "xc7z020-1clg484-VVD", 
-    # : "xc7z020-1clg484-YOSYS-VVD", 
-    # : "xc7z045-2ffg900-VVD",
+    # : "xc7z020-1clg484-YOSYS", 
+    # : "xc7z045-2ffg900",
 
     # UltraScale / UltraScale+
-    # : "xcku060-3ffva1156-VVD", 
-    # : "xcu280-2Lfsvh2892-VVD", 
-    "xcu55c-fsvh2892-2L-e" : {"device_name" : "xcu55c-2Lfsvh2892-VVD", "family" : "Xilinx"}
+    # : "xcku060-3ffva1156", 
+    # : "xcu250-2Lfigd2104",
+    # : "xcu280-2Lfsvh2892", 
+    # : "xcu50-2fsvh2104",
+    "xcu55c-fsvh2892-2L-e" : {"device_name" : "xcu55c-2Lfsvh2892", "family" : "Xilinx"}
 }
 
 

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -444,8 +444,8 @@ class BambuBackend(FPGABackend):
         ### RESET ###
         bambu_output_patterns = [
             "HLS_output", "panda-temp", "vivado_reports", "bambu_results*.xml", 
-            "evaluate*.sh", "memory_allocation*.xml" f"{project_name}-*_tb.exe", 
-            f"{project_name}.v", "results.txt", "synthesize*.sh", "panda_libtech.v"        
+            "evaluate*.sh", "memory_allocation*.xml", f"{project_name}-*_tb.exe", 
+            f"{project_name}.v", "results.txt", "synthesize*.sh", "panda_libtech.v", "*.mem"       
             ]
         matches = [p for pat in bambu_output_patterns for p in Path(project_dir).glob(pat)]
         is_dirty_directory = any(matches)

--- a/hls4ml/report/bambu_report.py
+++ b/hls4ml/report/bambu_report.py
@@ -7,31 +7,51 @@ from hls4ml.report.vivado_report import _parse_power_report, _parse_implementati
 def _coerce_value(raw):
     if raw is None:
         return None
-    raw = raw.strip()
-    if not raw:
-        return raw
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if not raw:
+            return raw
     try:
         return int(raw)
-    except ValueError:
+    except (ValueError, TypeError):
         try:
             return float(raw)
-        except ValueError:
+        except (ValueError, TypeError):
             return raw
 
 
 def _parse_result_file(path):
     tree = ET.parse(path)
     root = tree.getroot()
+
     meta = {
-        'Args': root.attrib.get('bambu_args'),
-        'Version': root.attrib.get('bambu_version'),
+        'Args':      root.attrib.get('args'),
+        'Version':   root.attrib.get('version'),
         'Timestamp': root.attrib.get('timestamp'),
-        'Benchmark': root.attrib.get('benchmark_name'),
-        'File': os.path.basename(path),
+        'Benchmark': root.attrib.get('benchmark'),
+        'File':      os.path.basename(path),
     }
+
     metrics = {}
-    for node in root:
-        metrics[node.tag] = _coerce_value(node.attrib.get('value'))
+
+    # --- Resource metrics (REGISTERS, SLACK, LUTS, etc.) ---
+    resources = root.find('resources')
+    if resources is not None:
+        for key, val in resources.attrib.items():
+            metrics[key] = _coerce_value(val)
+
+    # --- Timing / simulation metrics ---
+    # <timing><evaluation return_value="0"><run>X</run></evaluation></timing>
+    timing = root.find('timing')
+    if timing is not None:
+        evaluation = timing.find('evaluation')
+        if evaluation is not None:
+            runs = [_coerce_value(r.text) for r in evaluation.findall('run')]
+            if runs:
+                metrics['Total cycles']         = sum(runs)
+                metrics['Number of executions'] = len(runs)
+                metrics['Average execution']    = sum(runs) / len(runs)
+
     return {'meta': meta, 'metrics': metrics}
 
 

--- a/hls4ml/templates/bambu/build_lib.sh
+++ b/hls4ml/templates/bambu/build_lib.sh
@@ -56,7 +56,7 @@ elif [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-
     CC="$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16"
     echo "Found clang++-16 in Bambu AppImage usr/compilers directory."
 else
-    echo "Bambu AppImage not detected. Using fallback compiler."
+    echo "Bambu's clang++-16 not found. Using fallback compiler."
     CC="$FALLBACK_CC"
 fi
 

--- a/hls4ml/templates/bambu/build_lib.sh
+++ b/hls4ml/templates/bambu/build_lib.sh
@@ -34,6 +34,20 @@ if command -v "$APPIMAGE" >/dev/null 2>&1; then
     fi
 fi
 
+# If no Bambu AppImage: check for extracted AppImage (squashfs-root)
+if [ -z "$MOUNT_DIR" ]; then
+    BIN_PATH="$(which "$APPIMAGE" 2>/dev/null || true)"
+
+    if [ -n "$BIN_PATH" ]; then
+        APPDIR="$(dirname "$(dirname "$(dirname "$BIN_PATH")")")"
+
+        if [ -x "$APPDIR/usr/bin/clang++-16" ] || \
+           [ -x "$APPDIR/usr/compilers/clang-16/bin/clang++-16" ]; then
+            MOUNT_DIR="$APPDIR"
+        fi
+    fi
+fi
+
 # If Bambu provides Clang++-16, use it
 if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
     CC="$MOUNT_DIR/usr/bin/clang++-16"

--- a/hls4ml/templates/bambu/build_lib.sh
+++ b/hls4ml/templates/bambu/build_lib.sh
@@ -37,6 +37,10 @@ fi
 # If Bambu provides Clang++-16, use it
 if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
     CC="$MOUNT_DIR/usr/bin/clang++-16"
+    echo "Found clang++-16 in Bambu AppImage usr/bin directory."
+elif [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" ]; then
+    CC="$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16"
+    echo "Found clang++-16 in Bambu AppImage usr/compilers directory."
 else
     echo "Bambu AppImage not detected. Using fallback compiler."
     CC="$FALLBACK_CC"

--- a/hls4ml/templates/bambu/build_tb_exe.sh
+++ b/hls4ml/templates/bambu/build_tb_exe.sh
@@ -34,6 +34,20 @@ if command -v "$APPIMAGE" >/dev/null 2>&1; then
     fi
 fi
 
+# If no Bambu AppImage: check for extracted AppImage (squashfs-root)
+if [ -z "$MOUNT_DIR" ]; then
+    BIN_PATH="$(which "$APPIMAGE" 2>/dev/null || true)"
+
+    if [ -n "$BIN_PATH" ]; then
+        APPDIR="$(dirname "$(dirname "$(dirname "$BIN_PATH")")")"
+
+        if [ -x "$APPDIR/usr/bin/clang++-16" ] || \
+           [ -x "$APPDIR/usr/compilers/clang-16/bin/clang++-16" ]; then
+            MOUNT_DIR="$APPDIR"
+        fi
+    fi
+fi
+
 # If Bambu provides Clang++-16, use it
 if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
     CC="$MOUNT_DIR/usr/bin/clang++-16"

--- a/hls4ml/templates/bambu/build_tb_exe.sh
+++ b/hls4ml/templates/bambu/build_tb_exe.sh
@@ -56,7 +56,7 @@ elif [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-
    CC="$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16"
    echo "Found clang++-16 in Bambu AppImage usr/compilers directory."
 else
-    echo "Bambu AppImage not detected. Using fallback compiler."
+    echo "Bambu's clang++-16 not found. Using fallback compiler."
     CC="$FALLBACK_CC"
 fi
 

--- a/hls4ml/templates/bambu/build_tb_exe.sh
+++ b/hls4ml/templates/bambu/build_tb_exe.sh
@@ -37,6 +37,10 @@ fi
 # If Bambu provides Clang++-16, use it
 if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
     CC="$MOUNT_DIR/usr/bin/clang++-16"
+    echo "Found clang++-16 in Bambu AppImage usr/bin directory."
+elif [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" ]; then
+   CC="$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16"
+   echo "Found clang++-16 in Bambu AppImage usr/compilers directory."
 else
     echo "Bambu AppImage not detected. Using fallback compiler."
     CC="$FALLBACK_CC"

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -19,7 +19,7 @@ test_root_path = Path(__file__).parent
 def simple_model():
     """Simple Keras model for build testing"""
     model = Sequential()
-    model.add(Dense(3, input_shape=(2,)))
+    model.add(Dense(8, input_shape=(2,)))
     return model
 
 def count_files_with_extension(directory, extension):
@@ -116,7 +116,7 @@ def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, g
         output_data_tb=output_data_tb
     )
     hls_model_cosim.compile()
-    hls_model_cosim.build(synth=True, cosim=True, log_to_stdout=True)
+    hls_model_cosim.build(csim=False, synth=True, cosim=True, log_to_stdout=True)
 
     bridge_result = np.loadtxt(os.path.join(output_dir, 'tb_data', 'tb_output_predictions.dat'))
     cosim_result = np.loadtxt(os.path.join(output_dir, 'tb_data', 'rtl_cosim_results.log'))
@@ -183,7 +183,7 @@ def test_vsynth(test_case_id, simple_model, io_type, strategy, granularity, back
     # Bambu-specific artifact checks
     if backend == 'Bambu':
         # Ensure we get bambu results file
-        assert sum(1 for _ in vsynth_proj_dir.rglob("bambu_results_*.xml")) >= 1
+        assert sum(1 for _ in vsynth_proj_dir.rglob("bambu_results*.xml")) >= 1
 
         # Ensure we get expected reports
         if hls_model.config.get_config_value('FPGAFamily') == 'Xilinx':


### PR DESCRIPTION
# Description

Updated namings of files/devices to match new Bambu behavior. Added support for Bambu's compiler being located in /usr/compilers/. Added support for using Bambu's compiler if it is an **extracted AppImage**, not just a temporary mounted directory (the CI-CD Docker image does the former). Fixed some small problems in the tests

## Type of change

- [X ] Bug fix (non-breaking change that fixes an issue)

## Tests

Ran test_build_bambu.py on both WSL2 system and Rocky Linux Docker container

