### PR TITLE
[VitisUnified Backend]fix redundant fifo-depth optimization and fix kernel naming length error

### DIFF
--- a/hls4ml/backends/vitis_unified/passes/fifo_depth_optimization.py
+++ b/hls4ml/backends/vitis_unified/passes/fifo_depth_optimization.py
@@ -64,7 +64,7 @@ def execute_cosim_to_profile_fifos(model):
         reset=False,
         csim=False,
         synth=True,
-        cosim=False,
+        cosim=True,
         vsynth=False,
         fifo_opt=True,
         bitfile=False,

--- a/hls4ml/backends/vitis_unified/vitis_unified_backend.py
+++ b/hls4ml/backends/vitis_unified/vitis_unified_backend.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import warnings
 from shutil import copy2
 
 from hls4ml.backends import VitisBackend, VivadoBackend
@@ -25,6 +26,10 @@ class VitisUnifiedBackend(VitisBackend):
         bitfile=False,
         log_to_stdout=True,
     ):
+        if fifo_opt and not cosim:
+            warnings.warn('fifo_opt requires cosim to be enabled; cosim will be run automatically.', stacklevel=2)
+            cosim = True
+
         # it builds and return vivado reports
         if 'linux' in sys.platform:
             found = os.system('command -v v++ > /dev/null')
@@ -56,16 +61,16 @@ class VitisUnifiedBackend(VitisBackend):
 
         commands = []
         if synth:
-            self.prepare_sim_config_file(model, True)
+            self.prepare_sim_config_file(model, True, False)
             commands.append(('csynth', csynth_cmd, vitis_hls_dir))
             commands.append(('package', package_cmd, vitis_hls_dir))
 
         if csim:
-            self.prepare_sim_config_file(model, True)
+            self.prepare_sim_config_file(model, True, False)
             commands.append(('csim', csim_cmd, vitis_hls_dir))
 
         if cosim or fifo_opt:
-            self.prepare_sim_config_file(model, False)
+            self.prepare_sim_config_file(model, False, fifo_opt)
             commands.append(('cosim', cosim_cmd, vitis_hls_dir))
 
         if bitfile:
@@ -90,11 +95,20 @@ class VitisUnifiedBackend(VitisBackend):
                     stdout_target.close()
                     stderr_target.close()
 
-    def prepare_sim_config_file(self, model, is_csim):
+    def prepare_sim_config_file(self, model, is_csim, is_fifo_opt):
+        if is_csim and is_fifo_opt:
+            raise ValueError('fifo_opt requires cosim; cannot use fifo_opt with csim config.')
+
         suffix = 'csim' if is_csim else 'cosim'
         src = f'{model.config.get_output_dir()}/hls_kernel_config_{suffix}.cfg'
         des = f'{model.config.get_output_dir()}/hls_kernel_config.cfg'
         copy2(src, des)
+
+        with open(des) as f:
+            content = f.read()
+        with open(des, 'w') as f:
+            f.write(content.replace('{ENABLE_FIFO_SIZING}', 'true' if is_fifo_opt else 'false'))
+
         return des
 
     def create_initial_config(

--- a/hls4ml/templates/vitis_unified/hls_kernel_config.cfg
+++ b/hls4ml/templates/vitis_unified/hls_kernel_config.cfg
@@ -21,4 +21,4 @@ package.output.format={OUTPUT_KERNEL_TYPE}
 syn.compile.name_max_length=80
 syn.schedule.enable_dsp_full_reg=0
 package.output.syn=1
-cosim.enable_fifo_sizing=true
+cosim.enable_fifo_sizing={ENABLE_FIFO_SIZING}

--- a/hls4ml/writer/vitis_unified_writer.py
+++ b/hls4ml/writer/vitis_unified_writer.py
@@ -26,6 +26,16 @@ class VitisUnifiedWriter(VitisWriter):
         """No-op: Vitis Unified uses vitis-comp.json and hls_kernel_config, not project.tcl."""
         pass
 
+    # ===== sanity check function =====
+    def sanity_check(self, model, is_multigraph=False):
+        if is_multigraph:
+            raise Exception('Vitis Unified does not support multigraphs.')
+        decl = self._get_kernel_declaration(model)
+        if len(decl) > 64:
+            raise ValueError(
+                f"Project name must not exceed 18 characters; kernel declaration exceeds 64 characters: '{decl}'"
+            )
+
     # ===== Public helpers used by backend/passes =====
     def get_vitis_unified_working_directory(self, model):
         return os.path.join(model.config.get_output_dir(), 'vitis_workspace')
@@ -60,6 +70,11 @@ class VitisUnifiedWriter(VitisWriter):
 
     def _get_sim_file_name(self):
         return 'myproject_test'
+
+    def _get_kernel_declaration(self, model):
+        top_module_name = self._get_top_wrap_func_name(model, False)
+        top_mod_inst_name = top_module_name + '_1'
+        return f'{top_module_name}:1:{top_mod_inst_name}'
 
     def _get_top_wrap_func_name(self, model, is_axi_master):
         return self._get_wrapper_file_name(model, is_axi_master)
@@ -256,11 +271,10 @@ fi
                 if '{GUI_STATUS}' in line:
                     line = line.replace('{GUI_STATUS}', 'true')
                 if '# hls-fpga-machine-learning insert custom connection' in line and self._is_axi_stream():
-                    top_module_name = self._get_top_wrap_func_name(model, False)
-                    top_mod_inst_name = top_module_name + '_1'
+                    top_mod_inst_name = self._get_top_wrap_func_name(model, False) + '_1'
                     line += '\n'
                     line += '[connectivity]\n'
-                    line += f'nk={top_module_name}:1:{top_mod_inst_name}\n'
+                    line += f'nk={self._get_kernel_declaration(model)}\n'
                     line += f'stream_connect=DMA_MM2S:{top_mod_inst_name}.axi_input_stream\n'
                     line += f'stream_connect={top_mod_inst_name}.axi_output_stream:DMA_S2MM\n'
                 fout.write(line)
@@ -443,7 +457,7 @@ fi
         filedir = os.path.dirname(os.path.abspath(__file__))
 
         with (
-            open(os.path.join(filedir, f'../templates/vitis_unified/{self._get_project_name(model)}_axi_master.cpp')) as fin,
+            open(os.path.join(filedir, '../templates/vitis_unified/myproject_axi_master.cpp')) as fin,
             open(f'{model.config.get_output_dir()}/firmware/{self._get_wrapper_file_name(model, True)}.cpp', 'w') as fout,
         ):
             for line in fin.readlines():
@@ -752,8 +766,7 @@ fi
 
     # ===== Main entrypoint =====
     def write_hls(self, model, is_multigraph=False):
-        if is_multigraph:
-            raise Exception('Vitis Unified does not support multigraphs.')
+        self.sanity_check(model, is_multigraph)
 
         self._set_unified_config(model)
         super().write_hls(model, is_multigraph=False)

--- a/test/pytest/test_vitis_unified.py
+++ b/test/pytest/test_vitis_unified.py
@@ -58,6 +58,7 @@ def _vitis_unified_convert_kwargs(io_type, axi_mode, board='zcu102', **extra):
         'input_type': 'float',
         'output_type': 'float',
         'axi_mode': axi_mode,
+        'project_name': 'max_length_project',  # 18 chars → decl = 63 chars (limit is 64)
         **extra,
     }
 
@@ -235,7 +236,6 @@ def test_gen_unified(test_case_id, simple_unet, io_type, strategy, granularity, 
 
     config = hls4ml.utils.config_from_keras_model(model, granularity=granularity)
     config['Model']['Strategy'] = strategy
-    test_case_id = test_case_id
     output_dir = str(test_root_path / test_case_id)
 
     vitis_unified_model = hls4ml.converters.convert_from_keras_model(
@@ -260,6 +260,26 @@ def test_gen_unified(test_case_id, simple_unet, io_type, strategy, granularity, 
     assert os.path.isdir(final_reports_dir), f'final_reports directory does not exist: {final_reports_dir}'
     rpt_files = [f for f in os.listdir(final_reports_dir) if f.endswith('.rpt')]
     assert len(rpt_files) > 0, f'No .rpt files found in final_reports directory: {final_reports_dir}'
+
+
+@pytest.mark.parametrize('io_type', ['io_stream'])
+@pytest.mark.parametrize('strategy', ['latency'])
+@pytest.mark.parametrize('granularity', ['name'])
+@pytest.mark.parametrize('axi_mode', ['axi_stream', 'axi_master'])
+def test_project_name_too_long(test_case_id, simple_unet, io_type, strategy, granularity, axi_mode):
+    model = simple_unet
+    config = hls4ml.utils.config_from_keras_model(model, granularity=granularity)
+    config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / test_case_id)
+
+    vitis_unified_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        output_dir=output_dir,
+        **_vitis_unified_convert_kwargs(io_type, axi_mode, project_name='name_exceeds_limits'),  # 19 chars → decl = 65 chars
+    )
+    with pytest.raises(ValueError, match='Project name must not exceed 18 characters'):
+        vitis_unified_model.compile()
 
 
 # test_gen_unified('axi_stream_debug_4', simple_unet(), 'io_stream', 'latency', 'name', 10, 'axi_stream', 'kv260')


### PR DESCRIPTION
  Summary
                                                                                                    
  - Sanity checks in writer: Added sanity_check() to VitisUnifiedWriter that validates multigraph 
  support and enforces a maximum project name length of 18 characters (kernel declaration line must 
  fit within 64 characters). The multigraph check is consolidated here and write_hls now delegates
  to it.                                                                                            
  - _get_kernel_declaration helper: Extracted the repeated nk={module}:1:{module}_1 string        
  construction into a dedicated method, used by both sanity_check and _write_linker_config.         
  - FIFO sizing config: cosim.enable_fifo_sizing in hls_kernel_config.cfg is now driven by a
  {ENABLE_FIFO_SIZING} placeholder resolved at build time via prepare_sim_config_file, replacing a  
  hardcoded true.                                                                                 
  - fifo_opt + cosim enforcement: build() now warns (with stacklevel=2) and auto-enables cosim when 
  fifo_opt=True but cosim=False. prepare_sim_config_file raises a ValueError if fifo_opt is passed  
  with a csim config. The fifo_depth_optimization pass is also fixed to explicitly pass cosim=True.
  - Tests: Pinned project_name in shared test kwargs to max_length_project (18 chars, exactly at the
   limit). Added test_project_name_too_long parametrized over axi_mode to assert the ValueError is  
  raised for a 19-char name.
                                                                                                    
  Test plan                                                                                       

  - Existing tests pass with project_name='max_length_project' (18 chars, decl = 63 chars)          
  - test_project_name_too_long raises ValueError matching 'Project name must not exceed 18 
  characters' for both axi_stream and axi_master                                                    
  - build(fifo_opt=True, cosim=False) emits a UserWarning and still runs cosim                    
  - build(fifo_opt=True, cosim=True) runs silently without warning                                  
  - prepare_sim_config_file(model, is_csim=True, is_fifo_opt=True) raises ValueError              
  - Generated hls_kernel_config.cfg contains cosim.enable_fifo_sizing=true when fifo_opt=True and   
  cosim.enable_fifo_sizing=false otherwise  