### PR TITLE
Fix ARRAY_PARTITION pragma token and replace pointer arithmetic in Conv1D templates

### DIFF
--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_latency.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_latency.h
@@ -79,7 +79,8 @@ PartitionLoop:
             #pragma clang loop unroll(full)
             for (int i_res = 0; i_res < mult_n_out; i_res++) {
                 //#pragma HLS UNROLL
-                *(res++) = cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_res]);
+                res[(i_part * CONFIG_T::n_pixels + i_pxl) * mult_n_out + i_res] =
+                    cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             }
         }
     }

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_latency.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_latency.h
@@ -80,7 +80,7 @@ PartitionLoop:
             for (int i_res = 0; i_res < mult_n_out; i_res++) {
                 //#pragma HLS UNROLL
                 res[(i_part * CONFIG_T::n_pixels + i_pxl) * mult_n_out + i_res] =
-                    cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
+                  cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_res]);
             }
         }
     }

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
@@ -112,9 +112,11 @@ PartitionLoop:
           #pragma clang loop unroll(full)
           for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
             //#pragma HLS UNROLL
-            res[i_pxl * mult_n_out + i_res] =
+   
               cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
-        }
+            res[(i_part * CONFIG_T::n_pixels + i_pxl) * mult_n_out + i_res] =
+                    cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
+       }
     }
     }
 }

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
@@ -31,9 +31,8 @@ void conv_1d_resource_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
     #pragma HLS ARRAY_PARTITION variable=acc complete dim=0
 
 PartitionLoop:
-    #pragma clang loop unroll(full)
+    //#pragma clang loop unroll(full) We don't want this loop unrolled
     for (unsigned i_part = 0; i_part < CONFIG_T::n_partitions; i_part++) {
-        //#pragma HLS UNROLL // We don't want this loop unrolled
 
         CONFIG_T::template fill_buffer<data_T, CONFIG_T>::fill_buffer(data, data_buf, i_part);
 

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
@@ -90,18 +90,32 @@ PartitionLoop:
             }
         }
 
+        //PixelResultLoop:
+        // #pragma clang loop unroll(full)
+        // for (unsigned i_pxl = 0; i_pxl < CONFIG_T::n_pixels; i_pxl++) {
+        // //#pragma HLS UNROLL
+        // // Cast to "res_t" type
+        // ResultLoop:
+        //     #pragma clang loop unroll(full)
+        //     for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
+        //         //#pragma HLS UNROLL
+        //         *(res++) = cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
+        //     }
+        // }
+
     PixelResultLoop:
         #pragma clang loop unroll(full)
         for (unsigned i_pxl = 0; i_pxl < CONFIG_T::n_pixels; i_pxl++) {
-        //#pragma HLS UNROLL
-        // Cast to "res_t" type
+    // Cast to "res_t" type
+
         ResultLoop:
-            #pragma clang loop unroll(full)
-            for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
-                //#pragma HLS UNROLL
-                *(res++) = cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
-            }
+          #pragma clang loop unroll(full)
+          for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
+            //#pragma HLS UNROLL
+            res[i_pxl * mult_n_out + i_res] =
+              cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
         }
+    }
     }
 }
 

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_resource.h
@@ -112,8 +112,6 @@ PartitionLoop:
           #pragma clang loop unroll(full)
           for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
             //#pragma HLS UNROLL
-   
-              cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             res[(i_part * CONFIG_T::n_pixels + i_pxl) * mult_n_out + i_res] =
                     cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
        }

--- a/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_stream.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_conv1d_stream.h
@@ -35,7 +35,8 @@ void conv_1d_encoded_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
         //#pragma HLS STREAM variable=data_window[i_out] depth=win_depth
     }
 
-    #pragma HLS ARRAY_PARTITION variable=CONFIG_T::pixels complete
+    const ap_uint<CONFIG_T::filt_width> (&pixels)[CONFIG_T::min_width] = CONFIG_T::pixels;
+    #pragma HLS ARRAY_PARTITION variable=pixels complete
 
     res_T res_pack;
     PRAGMA_DATA_PACK(res_pack)

--- a/test/pytest/test_keras_api.py
+++ b/test/pytest/test_keras_api.py
@@ -137,6 +137,8 @@ padds_options = ['same', 'valid']
         ('Vitis', 'Latency'),
         ('Quartus', 'Resource'),
         ('oneAPI', 'Resource'),
+        ('Bambu', 'Resource'),
+        ('Bambu', 'Latency')
     ],
 )
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
@@ -175,7 +177,7 @@ def test_conv1d(test_case_id, padds, backend, strategy, io_type, synthesis_confi
     # 5e-2 might be too high
     np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0, atol=5e-2)
 
-    if not (backend in ['Vivado', 'Vitis'] and io_type == 'io_stream' and padds == 'same'):
+    if not (backend in ['Vivado', 'Vitis', 'Bambu'] and io_type == 'io_stream' and padds == 'same'):
         # Vivado/Vitis inserts and additional layer for 'same' padding in io_stream
         assert len(model.layers) + 2 == len(hls_model.get_layers())
         assert list(hls_model.get_layers())[1].attributes['name'] == model.layers[0]._name


### PR DESCRIPTION
# Description

Fixes Bambu-specific issues in Conv1D, specifically:
- Replaced qualified variable names in `#pragma HLS ARRAY_PARTITION` with local references, as Bambu requires plain variable names.
- Replaced pointer arithmetic (`*(res++)`) with explicit flat indexing on the output array to avoid array partitioning errors during bambu optimization passes
- Disabled unrolling for `PartitionLoop` in the Resource template, aligning it with the Vitis strategy.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Tests
- Added Bambu backend validation to `test_keras_api.py::test_conv1d`, which passes successfully.