### PR TITLE
Include bambu-accelerator

### DIFF
--- a/hls4ml/backends/__init__.py
+++ b/hls4ml/backends/__init__.py
@@ -15,6 +15,8 @@ from hls4ml.backends.vitis.vitis_backend import VitisBackend  # isort: skip
 
 from hls4ml.backends.bambu.bambu_backend import BambuBackend  # isort: skip
 
+from hls4ml.backends.bambu.bambu_accelerator_backend import BambuAcceleratorBackend  # isort: skip
+
 
 def _register_builtin_backends():
     register_backend('Vivado', VivadoBackend)
@@ -26,6 +28,7 @@ def _register_builtin_backends():
     register_backend('oneAPI', OneAPIBackend)
     register_backend('Libero', LiberoBackend)
     register_backend('Bambu', BambuBackend)
+    register_backend('BambuAccelerator', BambuAcceleratorBackend)
 
 
 _register_builtin_backends()

--- a/hls4ml/backends/bambu/bambu_accelerator_backend.py
+++ b/hls4ml/backends/bambu/bambu_accelerator_backend.py
@@ -1,0 +1,245 @@
+import inspect
+import os
+import subprocess
+from warnings import warn
+
+from hls4ml.backends.bambu.bambu_backend import BambuBackend
+from hls4ml.model.flow import register_flow
+from hls4ml.model.optimizer import get_backend_passes
+from hls4ml.model.optimizer.optimizer import extract_optimizers_from_path
+
+
+class BambuAcceleratorBackend(BambuBackend):
+    """Extends BambuBackend with a float wrapper around the ap_fixed HLS core.
+
+    Generates additional files:
+      - firmware/<proj>_float.h / .cpp  : flat float interface
+      - <proj>_float_test.cpp           : float testbench
+      - build_tb_float_exe.sh           : builds float testbench executable
+      - build_lib.sh (overwritten)      : includes float wrapper in shared lib
+    """
+
+    def __init__(self):
+        # Skip BambuBackend.__init__ to set our own name, then call FPGABackend.__init__
+        super(BambuBackend, self).__init__(name='BambuAccelerator')
+        self._register_layer_attributes()
+        self._register_flows()
+
+    def _init_file_optimizers(self):
+        """Override to walk the full MRO and deduplicate passes directories.
+
+        The default implementation only looks at direct bases + self:
+          [*self.__class__.__bases__, self.__class__]
+        For BambuBackend that's [FPGABackend, BambuBackend], so fpga/passes/ is
+        correctly included. For BambuAcceleratorBackend the direct base is
+        BambuBackend (not FPGABackend), so fpga/passes/ would be skipped and
+        passes like clone_output/reshape_stream would be missing.
+
+        We walk the full MRO (excluding object) and deduplicate by path so
+        bambu/passes/ is only loaded once even though both BambuBackend and
+        BambuAcceleratorBackend share the same directory.
+        """
+        file_optimizers = {}
+        seen_paths = set()
+        mro_classes = [c for c in type(self).__mro__ if c is not object]
+        for cls in mro_classes:
+            try:
+                opt_path = os.path.dirname(inspect.getfile(cls)) + '/passes'
+            except (TypeError, OSError):
+                continue
+            if opt_path in seen_paths:
+                continue
+            seen_paths.add(opt_path)
+            module_path = cls.__module__[: cls.__module__.rfind('.')] + '.passes'
+            cls_optimizers = extract_optimizers_from_path(opt_path, module_path, self)
+            file_optimizers.update(cls_optimizers)
+        return file_optimizers
+
+    def _register_flows(self):
+        bk = self.name.lower()  # 'bambuaccelerator'
+
+        initializers = self._get_layer_initializers()
+        init_flow = register_flow('init_layers', initializers, requires=['optimize'], backend=self.name)
+
+        streaming_passes = [
+            f'{bk}:inplace_stream_flatten',
+            f'{bk}:reshape_stream',
+            f'{bk}:clone_output',
+            f'{bk}:insert_zero_padding_before_conv1d',
+            f'{bk}:insert_zero_padding_before_conv2d',
+            f'{bk}:broadcast_stream',
+        ]
+        streaming_flow = register_flow('streaming', streaming_passes, requires=[init_flow], backend=self.name)
+
+        quantization_passes = [
+            f'{bk}:merge_batch_norm_quantized_tanh',
+            f'{bk}:quantize_dense_output',
+            'fuse_consecutive_batch_normalization',
+            f'{bk}:xnor_pooling',
+        ]
+        quantization_flow = register_flow('quantization', quantization_passes, requires=[init_flow], backend=self.name)
+
+        optimization_passes = [
+            f'{bk}:remove_final_reshape',
+            f'{bk}:optimize_pointwise_conv',
+            f'{bk}:inplace_parallel_reshape',
+            f'{bk}:inplace_stream_flatten',
+            f'{bk}:skip_softmax',
+            f'{bk}:fix_softmax_table_size',
+            'infer_precision_types',
+            f'{bk}:distributed_arithmetic_codegen',
+            f'{bk}:distributed_arithmetic_einsum_codegen',
+            f'{bk}:fuse_quantizer_into_d_a_layers',
+            f'{bk}:process_fixed_point_quantizer_layer',
+        ]
+        optimization_flow = register_flow('optimize', optimization_passes, requires=[init_flow], backend=self.name)
+
+        bambu_types = [
+            f'{bk}:transform_types',
+            f'{bk}:register_bram_weights',
+            f'{bk}:generate_conv_streaming_instructions',
+            f'{bk}:apply_resource_strategy',
+            f'{bk}:generate_conv_im2col',
+            f'{bk}:generate_unrolled_dense_resource',
+            f'{bk}:set_pipeline_style',
+            f'{bk}:d_a_latency_dense_template',
+            f'{bk}:d_a_latency_conv_template',
+        ]
+        bambu_types_flow = register_flow('specific_types', bambu_types, requires=[init_flow], backend=self.name)
+
+        templates = self._get_layer_templates()
+        template_flow = register_flow('apply_templates', self._get_layer_templates, requires=[init_flow], backend=self.name)
+
+        writer_passes = ['make_stamp', f'{bk}:write_hls']
+        self._writer_flow = register_flow('write', writer_passes, requires=[f'{bk}:ip'], backend=self.name)
+
+        fifo_depth_opt_passes = [f'{bk}:fifo_depth_optimization'] + writer_passes
+        register_flow('fifo_depth_optimization', fifo_depth_opt_passes, requires=[f'{bk}:ip'], backend=self.name)
+
+        all_passes = get_backend_passes(self.name)
+
+        extras = [
+            opt_pass
+            for opt_pass in all_passes
+            if opt_pass
+            not in initializers
+            + streaming_passes
+            + quantization_passes
+            + optimization_passes
+            + bambu_types
+            + templates
+            + writer_passes
+            + fifo_depth_opt_passes
+        ]
+
+        if len(extras) > 0:
+            for opt in extras:
+                warn(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
+
+        ip_flow_requirements = [
+            'optimize',
+            init_flow,
+            streaming_flow,
+            quantization_flow,
+            optimization_flow,
+            bambu_types_flow,
+            template_flow,
+        ]
+
+        self._default_flow = register_flow('ip', None, requires=ip_flow_requirements, backend=self.name)
+
+    def _get_hls_sources(self, project_name):
+        # myproject.cpp is still emitted for the CPU testbench (myproject_test.cpp)
+        # but it must NOT be handed to Bambu: the accelerator writer inlines the full
+        # layer pipeline directly into myproject_float.cpp, so Bambu only synthesises
+        # a single top-level function with all DATAFLOW streams visible at the outer
+        # scope.
+        return [os.path.join('firmware', f'{project_name}_float.cpp')]
+
+    def _get_top_fname(self, project_name):
+        return f'{project_name}_float'
+
+    def _get_cosim_testbench(self, project_name):
+        return f'{project_name}_float_test.cpp'
+
+    def build(
+        self,
+        model,
+        *,
+        reset=False,
+        csim=True,
+        synth=True,
+        cosim=False,
+        validation=False,
+        export=False,
+        vsynth=False,
+        fifo_opt=False,
+        log_to_stdout=True,
+        args=None,
+        env=None,
+        run_kwargs=None,
+    ):
+        """Run build, using the float testbench for C-simulation.
+
+        Mirrors the BambuBackend.build() signature exactly.  csim=True compiles
+        and runs the float testbench (*_float_tb.exe) instead of the ap_fixed
+        one.  All other arguments (synth, cosim, vsynth, …) behave identically
+        to BambuBackend.build().
+        """
+        # Replicate the parent's validation pre-check here because we suppress
+        # csim=True when calling super() and the parent would otherwise raise.
+        if validation and not (csim and cosim):
+            raise ValueError("To validate C simulation & RTL simulation equality, csim and cosim must both be run.")
+
+        # Pass csim=False so the parent never builds/runs the ap_fixed testbench.
+        # Pass validation=False so the parent's own pre-check doesn't fire.
+        result = super().build(
+            model,
+            reset=reset,
+            csim=False,
+            synth=synth,
+            cosim=cosim,
+            validation=False,
+            export=export,
+            vsynth=vsynth,
+            fifo_opt=fifo_opt,
+            log_to_stdout=log_to_stdout,
+            args=args,
+            env=env,
+            run_kwargs=run_kwargs,
+        )
+
+        if csim:
+            self._build_float_testbench_exe(model)
+
+            project_name = model.config.get_project_name()
+            stamp = model.config.get_config_value('Stamp')
+            project_dir = model.config.get_output_dir()
+
+            ret = subprocess.run(
+                [f'./{project_name}-{stamp}_float_tb.exe'],
+                cwd=project_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if ret.returncode != 0:
+                raise RuntimeError(
+                    f'Float testbench execution failed:\nSTDOUT:\n{ret.stdout}\nSTDERR:\n{ret.stderr}'
+                )
+
+        return result
+
+    def _build_float_testbench_exe(self, model):
+        ret = subprocess.run(
+            ['bash', 'build_tb_float_exe.sh'],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=model.config.get_output_dir(),
+        )
+        if ret.returncode != 0:
+            raise RuntimeError(
+                f'Failed to build float testbench executable for "{model.config.get_project_name()}":\n'
+                f'STDOUT:\n{ret.stdout}\nSTDERR:\n{ret.stderr}'
+            )

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -418,10 +418,7 @@ class BambuBackend(FPGABackend):
         part_family = model.config.get_config_value("FPGAFamily")
 
         # Bambu-specific command/flags
-        BASE_COMMAND  = ['bambu', 
-                         os.path.join('firmware', f'{project_name}.cpp'), 
-                         f'--top-fname={project_name}'
-                        ]
+        BASE_COMMAND = ['bambu'] + self._get_hls_sources(project_name) + [f'--top-fname={self._get_top_fname(project_name)}']
         if os.environ.get('USE_BAMBU_AC_TYPES'):
             REQ_ARGS = ['-lm',
                         '--compiler=I386_CLANG16',
@@ -483,7 +480,7 @@ class BambuBackend(FPGABackend):
             if not synth:
                 raise ValueError("To run RTL cosimulation, C/RTL synthesis must be run.")
             # --simulator=<SIMULATOR> will be selected by default by Bambu
-            CMD_ARGS += [f'--generate-tb={project_name}_test.cpp', '--simulate', '-DRTL_SIM']
+            CMD_ARGS += [f'--generate-tb={self._get_cosim_testbench(project_name)}', '--simulate', '-DRTL_SIM']
 
         ### VALIDATION ###
         if validation:
@@ -613,7 +610,19 @@ class BambuBackend(FPGABackend):
             result.update(parse_bambu_report(project_dir, part_family))
 
             return result
-        
+
+    def _get_hls_sources(self, project_name):
+        """Return the list of C++ source files to pass to Bambu."""
+        return [os.path.join('firmware', f'{project_name}.cpp')]
+
+    def _get_top_fname(self, project_name):
+        """Return the top-level function name for Bambu synthesis."""
+        return project_name
+
+    def _get_cosim_testbench(self, project_name):
+        """Return the testbench filename for Bambu RTL co-simulation."""
+        return f'{project_name}_test.cpp'
+
     def _build_testbench_exe(self, model):
         ret = subprocess.run(
             ['bash', 'build_tb_exe.sh'],

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -9,8 +9,8 @@ from warnings import warn
 import numpy as np
 
 from hls4ml.backends import FPGABackend
-from hls4ml.backends.bambu.bambu_types import BambuArrayVariableConverter
-from hls4ml.backends.fpga.fpga_types import APTypeConverter, HLSTypeConverter
+from hls4ml.backends.bambu.bambu_types import BambuArrayVariableConverter, BambuHLSTypeConverter
+from hls4ml.backends.fpga.fpga_types import APTypeConverter
 from hls4ml.model.attributes import ChoiceAttribute, ConfigurableAttribute, TypeAttribute
 from hls4ml.model.flow import register_flow
 from hls4ml.model.layers import (
@@ -1102,7 +1102,7 @@ class BambuBackend(FPGABackend):
     def init_garnet(self, layer):
         reuse_factor = layer.attributes['reuse_factor']
 
-        var_converter = BambuArrayVariableConverter(type_converter=HLSTypeConverter(precision_converter=APTypeConverter()))
+        var_converter = BambuArrayVariableConverter(type_converter=BambuHLSTypeConverter(precision_converter=APTypeConverter()))
 
         # A bit controversial but we are going to set the partitioning of the input here
         in_layer = layer.model.graph[layer.inputs[0]]

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -82,7 +82,7 @@ partname_to_bambu = {
     # : "xc6vlx240t-1ff1156", 
 
     # 7-series
-    "xc7a100tcsg324-1" : {"device_name" : "xc7a100t-1csg324-VVD", "family" : "Xilinx"}, # 7-series Artix! vsynth confirmed working, using as default for now
+    "xc7a100tcsg324-1" : {"device_name" : "xc7a100t-1csg324", "family" : "Xilinx"}, # 7-series Artix; matches the entry in Bambu's `Available devices` listing
     # : "xc7vx330t-1ffg1157",
     # : "xc7vx485t-2ffg1761-VVD",
     # : "xc7vx690t-3ffg1930-VVD", 
@@ -94,7 +94,7 @@ partname_to_bambu = {
     # UltraScale / UltraScale+
     # : "xcku060-3ffva1156-VVD", 
     # : "xcu280-2Lfsvh2892-VVD", 
-    "xcu55c-fsvh2892-2L-e" : {"device_name" : "xcu55c-2Lfsvh2892-VVD", "family" : "Xilinx"}
+    "xcu55c-fsvh2892-2L-e" : {"device_name" : "xcu55c-2Lfsvh2892", "family" : "Xilinx"}
 }
 
 
@@ -479,8 +479,18 @@ class BambuBackend(FPGABackend):
         if cosim:
             if not synth:
                 raise ValueError("To run RTL cosimulation, C/RTL synthesis must be run.")
-            # --simulator=<SIMULATOR> will be selected by default by Bambu
             CMD_ARGS += [f'--generate-tb={self._get_cosim_testbench(project_name)}', '--simulate', '-DRTL_SIM']
+
+            # Force Verilator for NanoXplore parts. Bambu's default
+            # simulator selection picks a NanoXplore-native flow whose
+            # XML device files fail to parse on the current toolchain
+            # (`Error during XML parsing of device files`). Verilator is
+            # toolchain-agnostic and works for cosim regardless of the
+            # target FPGA family.
+            part_name = model.config.get_config_value('Part')
+            family = partname_to_bambu.get(part_name, {}).get("family", None)
+            if family == 'NanoXplore':
+                CMD_ARGS += ['--simulator=VERILATOR']
 
         ### VALIDATION ###
         if validation:
@@ -639,11 +649,15 @@ class BambuBackend(FPGABackend):
     def _final_report_copying_code(self, family):
         """Aggregate final reports in one directory based on Part Family/Software used"""
         if family == 'Xilinx':
+            # Bambu's Vivado-flow output directory has moved across releases
+            # (`HLS_output/Synthesis/vivado_flow` in older versions,
+            # `HLS_output/xilinx/flow_backend` in current). Search the full
+            # HLS_output tree so the script keeps working across versions.
             return(
-                'src_root="HLS_output/Synthesis/vivado_flow"\n'
+                'src_root="HLS_output"\n'
                 'dst_root="vivado_reports"\n'
                 'mkdir -p "$dst_root"\n'
-                'find "$src_root" -type f \( -iname "*.rpt" -o -iname "*.xml" \) -exec cp -p {} "$dst_root"/ \;'
+                r'find "$src_root" -type f \( -iname "*.rpt" -o -iname "*.xml" \) -exec cp -p {} "$dst_root"/ \;'
             )
         else: # TODO: Add more parsing code for different families/softwares
             return ""

--- a/hls4ml/backends/bambu/bambu_backend.py
+++ b/hls4ml/backends/bambu/bambu_backend.py
@@ -474,6 +474,19 @@ class BambuBackend(FPGABackend):
                 raise RuntimeError(
                 f'C++ testbench execution failed:\nSTDOUT:\n{ret.stdout}\nSTDERR:\n{ret.stderr}'
             )
+                
+        if synth:
+            clock_period = model.config.get_config_value('ClockPeriod')
+            part_name = model.config.get_config_value('Part') # Bambu uses its own 'device name' which does NOT always coincide with part name
+            device_name = partname_to_bambu.get(part_name, {}).get("device_name", None)
+            if device_name is None:
+                warn(
+                    f"WARNING: Part name {part_name} has no registered mapping to a Bambu --device-name. "
+                    f"Using '--device-name={part_name}'. "
+                    "(See valid Bambu device names by running Bambu with High Verbosity flag '-v4')"
+                )
+                device_name = part_name
+            CMD_ARGS += [f'--device-name={device_name}', f'--clock-period={clock_period}']
             
         ### COSIM ###
         if cosim:
@@ -508,18 +521,7 @@ class BambuBackend(FPGABackend):
             if not cosim:
                 raise ValueError("To synthesize for specific part in Bambu, RTL cosimulation must be run.")
 
-            clock_period = model.config.get_config_value('ClockPeriod')
-            part_name = model.config.get_config_value('Part') # Bambu uses its own 'device name' which does NOT always coincide with part name
-            device_name = partname_to_bambu.get(part_name, {}).get("device_name", None)
-            if device_name is None:
-                warn(
-                    f"WARNING: Part name {part_name} has no registered mapping to a Bambu --device-name. "
-                    f"Using '--device-name={part_name}'. "
-                    "(See valid Bambu device names by running Bambu with High Verbosity flag '-v4')"
-                )
-                device_name = part_name
-
-            CMD_ARGS += ['--evaluation', f'--device-name={device_name}', f'--clock-period={clock_period}']
+            CMD_ARGS += ['--evaluation']
             
         ### FIFO_OPT ### 
         if fifo_opt:

--- a/hls4ml/backends/bambu/bambu_types.py
+++ b/hls4ml/backends/bambu/bambu_types.py
@@ -1,9 +1,82 @@
 from hls4ml.backends.fpga.fpga_types import (
     ArrayVariableConverter,
+    CompressedTypeConverter,
+    ExponentTypeConverter,
+    HLSTypeConverter,
     InplaceStreamVariableConverter,
+    NamedTypeConverter,
     StreamVariableConverter,
+    TypeDefinition,
+    TypePrecisionConverter,
     VariableDefinition,
 )
+from hls4ml.model.types import CompressedType, ExponentType, NamedType, PackedType
+
+
+# region PackedType
+#
+# Bug A workaround: emit a concrete (non-template) struct per stream payload
+# type instead of `typedef nnet::array<T,N> name;`. With the templated
+# typedef, Bambu's InterfaceInfer reads the AXIS TDATA Bitwidth from the
+# inner element (W) instead of the aggregate (N*W); the simulator's
+# per-beat channel layout then doesn't match the C-sim gold reference, and
+# cosim aborts with
+#     ERROR: MDPI driver: Channel parameter mismatch with respect to gold
+# A concrete struct with the same members forces InterfaceInfer to use
+# sizeof(struct) for the AXIS Bitwidth.
+# (Explicit specialization of `nnet::array` does NOT help — concrete struct
+# is the only emission Bambu picks up correctly.)
+
+
+class BambuPackedTypeConverter(TypeDefinition, TypePrecisionConverter):
+    def definition_cpp(self):
+        n_elem_expr = '/' if self.unpack else '*'
+        n_elem = str(self.n_elem) + n_elem_expr + str(self.n_pack)
+        precision = self.precision.definition_cpp()
+        name = self.name
+        # User-defined element-wise `operator=` (Bug B workaround). Without
+        # it, clang lowers `pack = stream.read()` as a single aggregate
+        # copy, which Bambu's InterfaceInfer setReadInterface pass refuses
+        # to handle:
+        #   error -> unexpected condition (gc->args.size() == 2)
+        #     void InterfaceInfer::setReadInterface(...)
+        # The element-wise loop body lowers to per-element loads/stores
+        # that setReadInterface pattern-matches.
+        return (
+            f'struct {name} {{\n'
+            f'    typedef {precision} value_type;\n'
+            f'    static const unsigned size = {n_elem};\n'
+            f'    {precision} data[{n_elem}];\n'
+            f'    {precision} &operator[](size_t pos) {{ return data[pos]; }}\n'
+            f'    const {precision} &operator[](size_t pos) const {{ return data[pos]; }}\n'
+            f'    {name} &operator=(const {name} &other) {{\n'
+            f'        if (&other == this) return *this;\n'
+            f'        #pragma clang loop unroll(full)\n'
+            f'        for (unsigned i = 0; i < size; i++) data[i] = other.data[i];\n'
+            f'        return *this;\n'
+            f'    }}\n'
+            f'    bool operator==(const {name} &other) const {{\n'
+            f'        for (unsigned i = 0; i < size; i++)\n'
+            f'            if (data[i] != other.data[i]) return false;\n'
+            f'        return true;\n'
+            f'    }}\n'
+            f'    bool operator!=(const {name} &other) const {{ return !(*this == other); }}\n'
+            f'}};\n'
+        )
+
+
+class BambuHLSTypeConverter(HLSTypeConverter):
+    def __init__(self, precision_converter):
+        self.precision_converter = precision_converter
+        self.type_map = {
+            NamedType: NamedTypeConverter,
+            CompressedType: CompressedTypeConverter,
+            ExponentType: ExponentTypeConverter,
+            PackedType: BambuPackedTypeConverter,
+        }
+
+
+# endregion
 
 # region ArrayVariable
 

--- a/hls4ml/backends/bambu/passes/core_templates.py
+++ b/hls4ml/backends/bambu/passes/core_templates.py
@@ -30,13 +30,19 @@ dense_config_template = """struct config{index} : nnet::dense_config {{
     typedef {bias_t.name} bias_t;
     typedef {weight_t.name} weight_t;
     typedef {index_t.name} index_t;
+    // Bind weights/biases compile-time on the config so the streaming
+    // `nnet::dense` can reach them without a runtime array-pointer
+    // parameter — Bambu DATAFLOW pointer params read as all-zero at
+    // runtime regardless of ROM contents.
+    static constexpr const weight_t *weights = {w};
+    static constexpr const bias_t *biases = {b};
     template<class data_T, class res_T, class CONFIG_T>
     using kernel = {dense_function}<data_T, res_T, CONFIG_T>;
     template<class x_T, class y_T>
     using product = nnet::product::{product_type}<x_T, y_T>;
 }};\n"""
 
-dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
+dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output});'
 
 dense_include_list = ['nnet_utils/nnet_dense.h', 'nnet_utils/nnet_dense_compressed.h', 'nnet_utils/nnet_dense_stream.h']
 
@@ -53,6 +59,8 @@ class DenseConfigTemplate(LayerConfigTemplate):
         params['product_type'] = get_backend('bambu').product_type(
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
+        params['w'] = node.get_weights('weight').name
+        params['b'] = node.get_weights('bias').name
 
         namespace = params['namespace']
 
@@ -85,9 +93,6 @@ class DenseFunctionTemplate(FunctionCallTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
-        params['w'] = node.get_weights('weight').name
-        params['b'] = node.get_weights('bias').name
-
         return self.template.format(**params)
 
     def match(self, node):

--- a/hls4ml/backends/bambu/passes/transform_types.py
+++ b/hls4ml/backends/bambu/passes/transform_types.py
@@ -1,6 +1,7 @@
-from hls4ml.backends.fpga.fpga_types import APTypeConverter, HLSTypeConverter, StaticWeightVariableConverter
+from hls4ml.backends.fpga.fpga_types import APTypeConverter, StaticWeightVariableConverter
 from hls4ml.backends.bambu.bambu_types import (
     BambuArrayVariableConverter,
+    BambuHLSTypeConverter,
     BambuInplaceArrayVariableConverter,
     BambuInplaceStreamVariableConverter,
     BambuStreamVariableConverter,
@@ -11,7 +12,7 @@ from hls4ml.model.types import InplaceTensorVariable
 
 class TransformTypes(GlobalOptimizerPass):
     def __init__(self):
-        self.type_converter = HLSTypeConverter(precision_converter=APTypeConverter())
+        self.type_converter = BambuHLSTypeConverter(precision_converter=APTypeConverter())
         self.array_var_converter = BambuArrayVariableConverter(type_converter=self.type_converter)
         self.inplace_array_var_converter = BambuInplaceArrayVariableConverter(type_converter=self.type_converter)
         self.stream_var_converter = BambuStreamVariableConverter(type_converter=self.type_converter)

--- a/hls4ml/templates/bambu/build_lib.sh
+++ b/hls4ml/templates/bambu/build_lib.sh
@@ -34,11 +34,20 @@ if command -v "$APPIMAGE" >/dev/null 2>&1; then
     fi
 fi
 
-# If Bambu provides Clang++-16, use it
-if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
-    CC="$MOUNT_DIR/usr/bin/clang++-16"
-else
-    echo "Bambu AppImage not detected. Using fallback compiler."
+# If Bambu provides Clang++-16, use it. The AppImage layout has changed
+# across releases (older versions ship clang++-16 under usr/bin/, newer ones
+# under usr/compilers/clang-16/bin/), so probe both known locations.
+CC=""
+if [ -n "$MOUNT_DIR" ]; then
+    for candidate in \
+        "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" \
+        "$MOUNT_DIR/usr/bin/clang++-16"
+    do
+        if [ -x "$candidate" ]; then CC="$candidate"; break; fi
+    done
+fi
+if [ -z "$CC" ]; then
+    echo "Bambu AppImage clang++-16 not detected. Using fallback compiler."
     CC="$FALLBACK_CC"
 fi
 

--- a/hls4ml/templates/bambu/build_lib_float.sh
+++ b/hls4ml/templates/bambu/build_lib_float.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPIMAGE="bambu"
+FALLBACK_CC="g++"
+
+TMPINFO=""
+MOUNT_PID=""
+MOUNT_DIR=""
+
+cleanup() {
+    if [ -n "${MOUNT_PID:-}" ]; then kill "$MOUNT_PID" 2>/dev/null || true; fi
+    if [ -n "${TMPINFO:-}" ]; then rm -f "$TMPINFO" || true; fi
+}
+trap cleanup EXIT
+
+# Try to mount to Bambu AppImage to access C++ compiler
+if command -v "$APPIMAGE" >/dev/null 2>&1; then
+    TMPINFO="$(mktemp)"
+    "$APPIMAGE" --appimage-mount >"$TMPINFO" 2>&1 &
+    MOUNT_PID=$!
+
+    for _ in {1..100}; do
+        if [ -s "$TMPINFO" ]; then
+            MOUNT_DIR=$(sed -n '1p' "$TMPINFO" | tr -d '\r\n')
+            if [ -d "$MOUNT_DIR" ]; then break; fi
+        fi
+        sleep 0.05
+    done
+
+    if [ ! -d "$MOUNT_DIR" ]; then
+        MOUNT_DIR=""
+        MOUNT_PID=""
+    fi
+fi
+
+# If Bambu provides Clang++-16, use it. The AppImage layout has changed
+# across releases (older versions ship clang++-16 under usr/bin/, newer ones
+# under usr/compilers/clang-16/bin/), so probe both known locations.
+CC=""
+if [ -n "$MOUNT_DIR" ]; then
+    for candidate in \
+        "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" \
+        "$MOUNT_DIR/usr/bin/clang++-16"
+    do
+        if [ -x "$candidate" ]; then CC="$candidate"; break; fi
+    done
+fi
+if [ -z "$CC" ]; then
+    echo "Bambu AppImage clang++-16 not detected. Using fallback compiler."
+    CC="$FALLBACK_CC"
+fi
+
+echo "Using compiler: $($CC --version | head -n1)"
+
+CFLAGS="-O3 -fPIC"
+
+# Include -std=c++23 if the compiler supports it (enables half and bfloat16 types, errors otherwise)
+if echo "" | $CC -Werror -fsyntax-only -std=c++23 -xc++ - -o /dev/null &>/dev/null; then
+    CFLAGS+=" -std=c++23"
+else
+    CFLAGS+=" -std=c++14"
+fi
+
+# Include -fno-gnu-unique if it is there
+if echo "" | $CC -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &>/dev/null; then
+    CFLAGS+=" -fno-gnu-unique"
+fi
+
+LDFLAGS=""
+INCFLAGS="-Ifirmware/ac_types/"
+PROJECT="myproject"
+LIB_STAMP="mystamp"
+BASEDIR="$(cd "$(dirname "$0")" && pwd)"
+WEIGHTS_DIR="\"${BASEDIR}/firmware/weights\""
+
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}.cpp -o ${PROJECT}.o
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}_float.cpp -o ${PROJECT}_float.o
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c ${PROJECT}_bridge.cpp -o ${PROJECT}_bridge.o
+$CC $CFLAGS $INCFLAGS -shared ${PROJECT}.o ${PROJECT}_float.o ${PROJECT}_bridge.o -o firmware/${PROJECT}-${LIB_STAMP}.so
+
+rm -f *.o
+
+echo "Done."

--- a/hls4ml/templates/bambu/build_tb_exe.sh
+++ b/hls4ml/templates/bambu/build_tb_exe.sh
@@ -34,11 +34,20 @@ if command -v "$APPIMAGE" >/dev/null 2>&1; then
     fi
 fi
 
-# If Bambu provides Clang++-16, use it
-if [ -n "$MOUNT_DIR" ] && [ -x "$MOUNT_DIR/usr/bin/clang++-16" ]; then
-    CC="$MOUNT_DIR/usr/bin/clang++-16"
-else
-    echo "Bambu AppImage not detected. Using fallback compiler."
+# If Bambu provides Clang++-16, use it. The AppImage layout has changed
+# across releases (older versions ship clang++-16 under usr/bin/, newer ones
+# under usr/compilers/clang-16/bin/), so probe both known locations.
+CC=""
+if [ -n "$MOUNT_DIR" ]; then
+    for candidate in \
+        "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" \
+        "$MOUNT_DIR/usr/bin/clang++-16"
+    do
+        if [ -x "$candidate" ]; then CC="$candidate"; break; fi
+    done
+fi
+if [ -z "$CC" ]; then
+    echo "Bambu AppImage clang++-16 not detected. Using fallback compiler."
     CC="$FALLBACK_CC"
 fi
 

--- a/hls4ml/templates/bambu/build_tb_float_exe.sh
+++ b/hls4ml/templates/bambu/build_tb_float_exe.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPIMAGE="bambu"
+FALLBACK_CC="g++"
+
+TMPINFO=""
+MOUNT_PID=""
+MOUNT_DIR=""
+
+cleanup() {
+    if [ -n "${MOUNT_PID:-}" ]; then kill "$MOUNT_PID" 2>/dev/null || true; fi
+    if [ -n "${TMPINFO:-}" ]; then rm -f "$TMPINFO" || true; fi
+}
+trap cleanup EXIT
+
+# Try to mount to Bambu AppImage to access C++ compiler
+if command -v "$APPIMAGE" >/dev/null 2>&1; then
+    TMPINFO="$(mktemp)"
+    "$APPIMAGE" --appimage-mount >"$TMPINFO" 2>&1 &
+    MOUNT_PID=$!
+
+    for _ in {1..100}; do
+        if [ -s "$TMPINFO" ]; then
+            MOUNT_DIR=$(sed -n '1p' "$TMPINFO" | tr -d '\r\n')
+            if [ -d "$MOUNT_DIR" ]; then break; fi
+        fi
+        sleep 0.05
+    done
+
+    if [ ! -d "$MOUNT_DIR" ]; then
+        MOUNT_DIR=""
+        MOUNT_PID=""
+    fi
+fi
+
+# If Bambu provides Clang++-16, use it. The AppImage layout has changed
+# across releases (older versions ship clang++-16 under usr/bin/, newer ones
+# under usr/compilers/clang-16/bin/), so probe both known locations.
+CC=""
+if [ -n "$MOUNT_DIR" ]; then
+    for candidate in \
+        "$MOUNT_DIR/usr/compilers/clang-16/bin/clang++-16" \
+        "$MOUNT_DIR/usr/bin/clang++-16"
+    do
+        if [ -x "$candidate" ]; then CC="$candidate"; break; fi
+    done
+fi
+if [ -z "$CC" ]; then
+    echo "Bambu AppImage clang++-16 not detected. Using fallback compiler."
+    CC="$FALLBACK_CC"
+fi
+
+echo "Using compiler: $($CC --version | head -n1)"
+
+CFLAGS="-O3 -fPIC"
+
+# Include -std=c++23 if the compiler supports it (enables half and bfloat16 types, errors otherwise)
+if echo "" | $CC -Werror -fsyntax-only -std=c++23 -xc++ - -o /dev/null &>/dev/null; then
+    CFLAGS+=" -std=c++23"
+else
+    CFLAGS+=" -std=c++14"
+fi
+
+# Include -fno-gnu-unique if it is there
+if echo "" | $CC -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &>/dev/null; then
+    CFLAGS+=" -fno-gnu-unique"
+fi
+
+LDFLAGS=""
+INCFLAGS="-Ifirmware/ac_types/"
+PROJECT="myproject"
+LIB_STAMP="mystamp"
+BASEDIR="$(cd "$(dirname "$0")" && pwd)"
+WEIGHTS_DIR="\"${BASEDIR}/firmware/weights\""
+
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}.cpp -o ${PROJECT}.o
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}_float.cpp -o ${PROJECT}_float.o
+$CC $CFLAGS $INCFLAGS -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c ${PROJECT}_float_test.cpp -o ${PROJECT}_float_test.o
+$CC ${PROJECT}.o ${PROJECT}_float.o ${PROJECT}_float_test.o -o ${PROJECT}-${LIB_STAMP}_float_tb.exe
+
+rm -f *.o
+
+echo "Executable built: ${PROJECT}-${LIB_STAMP}_float_tb.exe"

--- a/hls4ml/templates/bambu/firmware/myproject_float.h
+++ b/hls4ml/templates/bambu/firmware/myproject_float.h
@@ -1,0 +1,11 @@
+#ifndef MYPROJECT_FLOAT_H_
+#define MYPROJECT_FLOAT_H_
+
+#include "ac_int.h"
+// hls-fpga-machine-learning insert float-includes
+
+// hls-fpga-machine-learning insert definitions
+
+// hls-fpga-machine-learning insert float-signature
+
+#endif

--- a/hls4ml/templates/bambu/myproject_float_test.cpp
+++ b/hls4ml/templates/bambu/myproject_float_test.cpp
@@ -1,0 +1,82 @@
+#include <fstream>
+#include <iostream>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+
+#include "firmware/myproject_float.h"
+
+#ifdef  __BAMBU__
+#include <mdpi/mdpi_user.h>
+#endif
+
+#define CHECKPOINT 5000
+
+int main(int argc, char **argv) {
+    // load input data from text file
+    std::ifstream fin("tb_data/tb_input_features.dat");
+    // load predictions from text file
+    std::ifstream fpr("tb_data/tb_output_predictions.dat");
+
+#ifdef RTL_SIM
+    std::string RESULTS_LOG = "tb_data/rtl_cosim_results.log";
+#else
+    std::string RESULTS_LOG = "tb_data/csim_results.log";
+#endif
+    std::ofstream fout(RESULTS_LOG);
+
+    std::string iline;
+    std::string pline;
+    int e = 0;
+
+    if (fin.is_open() && fpr.is_open()) {
+        while (std::getline(fin, iline) && std::getline(fpr, pline)) {
+            if (e % CHECKPOINT == 0)
+                std::cout << "Processing input " << e << std::endl;
+            char *cstr = const_cast<char *>(iline.c_str());
+            char *current;
+            std::vector<float> in;
+            current = strtok(cstr, " ");
+            while (current != NULL) {
+                in.push_back(atof(current));
+                current = strtok(NULL, " ");
+            }
+            cstr = const_cast<char *>(pline.c_str());
+            std::vector<float> pr;
+            current = strtok(cstr, " ");
+            while (current != NULL) {
+                pr.push_back(atof(current));
+                current = strtok(NULL, " ");
+            }
+
+            // hls-fpga-machine-learning insert float-data
+
+            // hls-fpga-machine-learning insert float-top-level-function
+
+            e++;
+
+            // hls-fpga-machine-learning insert float-tb-output
+        }
+        fin.close();
+        fpr.close();
+    } else {
+        std::cout << "INFO: Unable to open input/predictions file, using default input." << std::endl;
+        const unsigned NUM_TEST_SAMPLES = 5;
+        for (unsigned i = 0; i < NUM_TEST_SAMPLES; i++) {
+            // hls-fpga-machine-learning insert float-zero
+
+            // hls-fpga-machine-learning insert float-top-level-function
+
+            // hls-fpga-machine-learning insert float-output
+
+            // hls-fpga-machine-learning insert float-tb-output
+        }
+    }
+
+    fout.close();
+    std::cout << "INFO: Saved inference results to file: " << RESULTS_LOG << std::endl;
+
+    return 0;
+}

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense.h
@@ -39,8 +39,8 @@ struct dense_config {
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-           typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-           typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+           const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+           const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
     #pragma HLS inline
     CONFIG_T::template kernel<data_T, res_T, CONFIG_T>::dense(data, res, weights, biases);
 }
@@ -48,8 +48,8 @@ void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
 template <class data_T, class res_T, typename CONFIG_T> class DenseLatency : public DenseKernel<data_T, res_T, CONFIG_T> {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                      typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                      const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                      const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
         //#pragma HLS INLINE
         dense_latency<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     }
@@ -59,8 +59,8 @@ template <class data_T, class res_T, typename CONFIG_T>
 class DenseResource_rf_leq_nin : public DenseKernel<data_T, res_T, CONFIG_T> {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                      typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                      const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                      const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
         //#pragma HLS INLINE
         dense_resource_rf_leq_nin<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     }
@@ -70,8 +70,8 @@ template <class data_T, class res_T, typename CONFIG_T>
 class DenseResource_rf_gt_nin_rem0 : public DenseKernel<data_T, res_T, CONFIG_T> {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                      typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                      const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                      const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
         //#pragma HLS INLINE
         dense_resource_rf_gt_nin_rem0<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     }

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense.h
@@ -45,6 +45,18 @@ void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
     CONFIG_T::template kernel<data_T, res_T, CONFIG_T>::dense(data, res, weights, biases);
 }
 
+// Two-argument overload: weights/biases come from CONFIG_T (compile-time
+// resolved class members). The Bambu backend emitter calls this form so
+// the wrapper's DATAFLOW scope doesn't pass weights as runtime pointer
+// parameters — those bind to `DF_bambu_*FO0` interfaces that read zero
+// at runtime.
+template <class data_T, class res_T, typename CONFIG_T>
+void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out]) {
+    #pragma HLS inline
+    CONFIG_T::template kernel<data_T, res_T, CONFIG_T>::dense(
+        data, res, CONFIG_T::weights, CONFIG_T::biases);
+}
+
 template <class data_T, class res_T, typename CONFIG_T> class DenseLatency : public DenseKernel<data_T, res_T, CONFIG_T> {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense_latency.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense_latency.h
@@ -11,8 +11,8 @@ namespace nnet {
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                   const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                   const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
     data_T cache;
     typename CONFIG_T::accum_t mult[CONFIG_T::n_in * CONFIG_T::n_out];
     typename CONFIG_T::accum_t acc[CONFIG_T::n_out];

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense_resource.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense_resource.h
@@ -11,8 +11,8 @@ namespace nnet {
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_resource_rf_leq_nin(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                               typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                               typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                               const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                               const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
 
     const int rufactor = CONFIG_T::reuse_factor;
     const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
@@ -88,8 +88,8 @@ Result:
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_resource_rf_gt_nin_rem0(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                                   const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                                   const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
 
     const int rufactor = MIN(CONFIG_T::reuse_factor, CONFIG_T::n_in * CONFIG_T::n_out);
     const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
@@ -173,8 +173,8 @@ Result:
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_resource_rf_gt_nin(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                              typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                              typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                              const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                              const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
 
     const int rufactor = CONFIG_T::reuse_factor;
     const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
@@ -265,8 +265,8 @@ Result:
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_resource(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                    typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                    typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                    const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                    const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
 
     #pragma HLS inline recursive
 

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense_stream.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense_stream.h
@@ -20,10 +20,14 @@ void dense_wrapper(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
     CONFIG_T::template kernel<data_T, res_T, CONFIG_T>::dense(data, res, weights, biases);
 }
 
+// Weights/biases are reached through `CONFIG_T` rather than taken as
+// pointer-array parameters: Bambu's DATAFLOW scheduler binds array-pointer
+// parameters of sub-functions to internal `DF_bambu_*FO0` interfaces that
+// read zero at runtime, regardless of what the .mem init file contains.
+// CONFIG_T::weights / ::biases are compile-time-resolved class members,
+// so the callee inlines them correctly.
 template <class data_T, class res_T, typename CONFIG_T>
-void dense(hls::stream<data_T> &data_stream, hls::stream<res_T> &res_stream,
-           const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-           const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+void dense(hls::stream<data_T> &data_stream, hls::stream<res_T> &res_stream) {
     typename data_T::value_type data[CONFIG_T::n_in];
     //#pragma HLS ARRAY_PARTITION variable=data complete
 
@@ -44,7 +48,8 @@ DataPrepare:
         }
     }
 
-    dense_wrapper<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(data, res, weights, biases);
+    dense_wrapper<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(
+        data, res, CONFIG_T::weights, CONFIG_T::biases);
 
 ResWrite:
     for (unsigned i_out = 0; i_out < CONFIG_T::n_out / res_T::size; i_out++) {

--- a/hls4ml/templates/bambu/nnet_utils/nnet_dense_stream.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_dense_stream.h
@@ -11,8 +11,8 @@ namespace nnet {
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense_wrapper(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                   const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                   const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
     #pragma HLS inline recursive
     if (CONFIG_T::strategy == nnet::latency || CONFIG_T::strategy == nnet::distributed_arithmetic) {
         //#pragma HLS PIPELINE II=CONFIG_T::reuse_factor
@@ -22,8 +22,8 @@ void dense_wrapper(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
 
 template <class data_T, class res_T, typename CONFIG_T>
 void dense(hls::stream<data_T> &data_stream, hls::stream<res_T> &res_stream,
-           typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-           typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+           const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+           const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
     typename data_T::value_type data[CONFIG_T::n_in];
     //#pragma HLS ARRAY_PARTITION variable=data complete
 

--- a/hls4ml/templates/bambu/nnet_utils/nnet_function_stubs.h
+++ b/hls4ml/templates/bambu/nnet_utils/nnet_function_stubs.h
@@ -31,8 +31,8 @@ template <class data_T, typename CONFIG_T> class FillConv2DBuffer {
 template <class data_T, class res_T, typename CONFIG_T> class DenseKernel {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                      typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                      const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                      const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
         // To be implemented in subclasses
     }
 };
@@ -40,8 +40,8 @@ template <class data_T, class res_T, typename CONFIG_T> class DenseKernel {
 template <class data_T, class res_T, typename CONFIG_T> class DepthwiseDenseKernel {
   public:
     static void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
-                      typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
-                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
+                      const typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                      const typename CONFIG_T::bias_t biases[CONFIG_T::n_out]) {
         // To be implemented in subclasses
     }
 };
@@ -49,8 +49,8 @@ template <class data_T, class res_T, typename CONFIG_T> class DepthwiseDenseKern
 template <class data_T, class res_T, typename CONFIG_T> class Conv1DKernel {
   public:
     static void conv(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
-                     typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-                     typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]) {
+                     const typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                     const typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]) {
         // To be implemented in subclasses
     }
 };

--- a/hls4ml/writer/__init__.py
+++ b/hls4ml/writer/__init__.py
@@ -1,4 +1,5 @@
 from hls4ml.writer.bambu_writer import BambuWriter
+from hls4ml.writer.bambu_accelerator_writer import BambuAcceleratorWriter  # isort: skip
 from hls4ml.writer.catapult_writer import CatapultWriter
 from hls4ml.writer.libero_writer import LiberoWriter
 from hls4ml.writer.oneapi_writer import OneAPIWriter
@@ -18,3 +19,4 @@ register_writer('Catapult', CatapultWriter)
 register_writer('Libero', LiberoWriter)
 register_writer('SymbolicExpression', SymbolicExpressionWriter)
 register_writer('Bambu', BambuWriter)
+register_writer('BambuAccelerator', BambuAcceleratorWriter)

--- a/hls4ml/writer/bambu_accelerator_writer.py
+++ b/hls4ml/writer/bambu_accelerator_writer.py
@@ -12,12 +12,16 @@ class BambuAcceleratorWriter(BambuWriter):
     (8/16/32/64-bit) that fits the fixed-point width, keeping the AXI bus aligned
     to 128 bits without introducing any IEEE 754 hardware.
 
-    This commit lands io_parallel only (a flat C-array interface). The wrapper
-    inlines the layer pipeline directly — it does NOT call `myproject()` from
-    the core. Inlining is what lets the same wrapper structure work for
-    io_stream too (next commit) where Bambu's DATAFLOW scheduler can't bind
-    sub-function array-pointer parameters correctly. For symmetry we use the
-    same wrapper layout for io_parallel.
+    Supports both io_parallel (flat C-array interface) and io_stream (AXIS of
+    scalars, one unsigned-container beat per ap_fixed scalar, packed into
+    nnet::array structs to feed the core IP's hls::stream interface).
+
+    The wrapper INLINES the layer pipeline directly — it does NOT call
+    `myproject()` from the core. Inlining is what lets the io_stream path
+    work: Bambu's DATAFLOW scheduler binds sub-function array-pointer
+    parameters to BRAMs that read zero at runtime, so all layer calls must
+    sit inside one DATAFLOW function. We use the same wrapper layout for
+    io_parallel for symmetry.
     """
 
     # The wrapper myproject_float owns the top-level interface. The inner
@@ -40,7 +44,12 @@ class BambuAcceleratorWriter(BambuWriter):
 
     @staticmethod
     def _var_precision(v):
-        """Return (total_bits, frac_bits) for a model variable."""
+        """Return (total_bits, frac_bits) for a model variable.
+
+        Works for both io_parallel (NamedType) and io_stream (PackedType)
+        because PackedType inherits from NamedType and stores the scalar
+        ap_fixed precision in the same .type.precision attribute.
+        """
         try:
             total = v.type.precision.width
             integer = v.type.precision.integer
@@ -59,10 +68,18 @@ class BambuAcceleratorWriter(BambuWriter):
         n_out = sum(v.size() for v in model.get_output_variables())
         return n_in, n_out
 
+    def _n_elem(self, v):
+        """Number of scalars packed per stream beat (= shape[-1] for io_stream, else 1)."""
+        try:
+            return v.type.n_elem
+        except AttributeError:
+            return 1
+
     def write_float_header(self, model):
         """Write firmware/<proj>_float.h"""
         filedir = os.path.dirname(os.path.abspath(__file__))
         proj = model.config.get_project_name()
+        io_type = model.config.get_config_value('IOType')
 
         n_in, n_out = self._compute_io_sizes(model)
         in_cw = self._max_container_width(model.get_input_variables())
@@ -79,6 +96,8 @@ class BambuAcceleratorWriter(BambuWriter):
 
             if '// hls-fpga-machine-learning insert float-includes' in line:
                 newline = line
+                if io_type == 'io_stream':
+                    newline += '#include "hls_stream.h"\n'
 
             elif '// hls-fpga-machine-learning insert definitions' in line:
                 newline = line
@@ -91,7 +110,10 @@ class BambuAcceleratorWriter(BambuWriter):
 
             elif '// hls-fpga-machine-learning insert float-signature' in line:
                 newline = line
-                newline += f'void {proj}_float(in_container_t input[N_IN], out_container_t output[N_OUT]);\n'
+                if io_type == 'io_stream':
+                    newline += f'void {proj}_float(hls::stream<in_container_t> &input_stream, hls::stream<out_container_t> &output_stream);\n'
+                else:
+                    newline += f'void {proj}_float(in_container_t input[N_IN], out_container_t output[N_OUT]);\n'
 
             else:
                 newline = line
@@ -106,9 +128,27 @@ class BambuAcceleratorWriter(BambuWriter):
     # inherited from BambuWriter (`_emit_core_*`, `_emit_load_weights_block`,
     # `_emit_internal_stream_decls`, `_emit_layer_calls`).
 
-    def _emit_ingest_helper(self, inp):
+    def _emit_ingest_helper(self, inp, io_type):
         """Static decode function: container -> core input variable."""
         total, _ = self._var_precision(inp)
+        if io_type == 'io_stream':
+            n_elem = self._n_elem(inp)
+            n_beats = inp.size() // n_elem
+            return (
+                f'static void ingest_{inp.name}('
+                f'hls::stream<in_container_t> &input_stream, '
+                f'hls::stream<{inp.type.name}> &{inp.name}) {{\n'
+                f'    for (int i = 0; i < {n_beats}; i++) {{\n'
+                f'        {inp.type.name} pack;\n'
+                f'        #pragma clang loop unroll(full)\n'
+                f'        for (int j = 0; j < {inp.type.name}::size; j++) {{\n'
+                f'            in_container_t raw = input_stream.read();\n'
+                f'            pack[j].set_slc(0, raw.slc<{total}>(0));\n'
+                f'        }}\n'
+                f'        {inp.name}.write(pack);\n'
+                f'    }}\n'
+                f'}}\n\n'
+            )
         return (
             f'static void ingest_{inp.name}('
             f'in_container_t input[N_IN], '
@@ -119,9 +159,27 @@ class BambuAcceleratorWriter(BambuWriter):
             f'}}\n\n'
         )
 
-    def _emit_egress_helper(self, out_var):
+    def _emit_egress_helper(self, out_var, io_type):
         """Static encode function: core output variable -> container."""
         total, _ = self._var_precision(out_var)
+        if io_type == 'io_stream':
+            n_elem = self._n_elem(out_var)
+            n_beats = out_var.size() // n_elem
+            return (
+                f'static void egress_{out_var.name}('
+                f'hls::stream<{out_var.type.name}> &{out_var.name}, '
+                f'hls::stream<out_container_t> &output_stream) {{\n'
+                f'    for (int i = 0; i < {n_beats}; i++) {{\n'
+                f'        {out_var.type.name} pack = {out_var.name}.read();\n'
+                f'        #pragma clang loop unroll(full)\n'
+                f'        for (int j = 0; j < {out_var.type.name}::size; j++) {{\n'
+                f'            out_container_t raw = 0;\n'
+                f'            raw.set_slc(0, pack[j].slc<{total}>(0));\n'
+                f'            output_stream.write(raw);\n'
+                f'        }}\n'
+                f'    }}\n'
+                f'}}\n\n'
+            )
         return (
             f'static void egress_{out_var.name}('
             f'{out_var.type.name} {out_var.name}[{out_var.size()}], '
@@ -134,45 +192,68 @@ class BambuAcceleratorWriter(BambuWriter):
             f'}}\n\n'
         )
 
-    def _emit_ingest_helpers(self, model):
-        return ''.join(self._emit_ingest_helper(inp) for inp in model.get_input_variables())
+    def _emit_ingest_helpers(self, model, io_type):
+        return ''.join(self._emit_ingest_helper(inp, io_type) for inp in model.get_input_variables())
 
-    def _emit_egress_helpers(self, model):
-        return ''.join(self._emit_egress_helper(o) for o in model.get_output_variables())
+    def _emit_egress_helpers(self, model, io_type):
+        return ''.join(self._emit_egress_helper(o, io_type) for o in model.get_output_variables())
 
-    def _emit_ingest_calls(self, model, indent='    '):
-        return ''.join(f'{indent}ingest_{inp.name}(input, {inp.name});\n' for inp in model.get_input_variables())
+    def _emit_ingest_calls(self, model, io_type, indent='    '):
+        port = 'input_stream' if io_type == 'io_stream' else 'input'
+        return ''.join(f'{indent}ingest_{inp.name}({port}, {inp.name});\n' for inp in model.get_input_variables())
 
-    def _emit_egress_calls(self, model, indent='    '):
-        return ''.join(f'{indent}egress_{o.name}({o.name}, output);\n' for o in model.get_output_variables())
+    def _emit_egress_calls(self, model, io_type, indent='    '):
+        port = 'output_stream' if io_type == 'io_stream' else 'output'
+        return ''.join(f'{indent}egress_{o.name}({o.name}, {port});\n' for o in model.get_output_variables())
 
-    def _emit_wrapper_signature(self, proj):
+    def _emit_wrapper_interface_pragmas(self, io_type):
+        """File-scope AXIS pragmas for the wrapper top-level (io_stream only).
+
+        io_parallel emits no interface pragma — Bambu's
+        `--generate-interface=INFER` derives it from the typed array
+        parameters in the wrapper signature.
+        """
+        if io_type != 'io_stream':
+            return ''
+        return (
+            '#pragma HLS interface mode=axis port=input_stream\n'
+            '#pragma HLS interface mode=axis port=output_stream\n'
+        )
+
+    def _emit_wrapper_signature(self, proj, io_type):
+        if io_type == 'io_stream':
+            return (
+                f'void {proj}_float('
+                f'hls::stream<in_container_t> &input_stream, '
+                f'hls::stream<out_container_t> &output_stream)\n'
+            )
         return f'void {proj}_float(in_container_t input[N_IN], out_container_t output[N_OUT])\n'
 
     def write_float_wrapper(self, model):
         """Write firmware/<proj>_float.cpp — ingest/egress helpers wrapping
         the inlined layer pipeline."""
         proj = model.config.get_project_name()
+        io_type = model.config.get_config_value('IOType')
         indent = '    '
 
-        # Bambu DATAFLOW (when active for io_stream) requires every local
-        # stream to be declared before any sub-function call; declarations
-        # first, then calls in pipeline order. The same layout works for
-        # io_parallel.
+        # Bambu DATAFLOW (active for io_stream) requires every local stream
+        # to be declared before any sub-function call; declarations first,
+        # then calls in pipeline order. The same layout works for io_parallel.
         parts = [
             f'#include "{proj}_float.h"\n',
             f'#include "{proj}.h"\n',
             '#include "parameters.h"\n',
             '\n',
-            self._emit_ingest_helpers(model),
-            self._emit_egress_helpers(model),
-            self._emit_wrapper_signature(proj),
+            self._emit_ingest_helpers(model, io_type),
+            self._emit_egress_helpers(model, io_type),
+            self._emit_wrapper_interface_pragmas(io_type),
+            self._emit_wrapper_signature(proj, io_type),
             '{\n',
             self._emit_core_io_pragma(model, indent=indent),
             self._emit_core_input_declarations(model, indent=indent),
             self._emit_core_output_declarations(model, indent=indent),
             self._emit_internal_stream_decls(model, indent=indent),
-            self._emit_ingest_calls(model, indent=indent),
+            self._emit_ingest_calls(model, io_type, indent=indent),
             self._emit_load_weights_block(model, indent=indent),
             # `_emit_load_weights_block` ends with `#endif` (no trailing
             # newline — kept byte-faithful to BambuBackend's existing
@@ -182,7 +263,7 @@ class BambuAcceleratorWriter(BambuWriter):
             # as garbage at end of #endif.
             '\n' if model.config.get_writer_config()['WriteWeightsTxt'] else '',
             self._emit_layer_calls(model, indent=indent),
-            self._emit_egress_calls(model, indent=indent),
+            self._emit_egress_calls(model, io_type, indent=indent),
             '}\n',
         ]
 
@@ -193,6 +274,7 @@ class BambuAcceleratorWriter(BambuWriter):
         """Write <proj>_float_test.cpp"""
         filedir = os.path.dirname(os.path.abspath(__file__))
         proj = model.config.get_project_name()
+        io_type = model.config.get_config_value('IOType')
 
         model_inputs = model.get_input_variables()
         model_outputs = model.get_output_variables()
@@ -208,37 +290,66 @@ class BambuAcceleratorWriter(BambuWriter):
 
             elif '// hls-fpga-machine-learning insert float-data' in line:
                 newline = line
-                newline += f'{indent}in_container_t input[N_IN];\n'
-                in_offset = 0
-                for inp in model_inputs:
-                    total, frac = self._var_precision(inp)
-                    scale = 1 << frac
-                    max_val = (1 << (total - 1)) - 1
-                    min_val = -(1 << (total - 1))
-                    newline += f'{indent}for(int i = 0; i < {inp.size()}; i++) {{\n'
-                    newline += f'{indent}    long long s = (long long)floor((double)in[{in_offset} + i] * {scale}LL);\n'
-                    newline += f'{indent}    if (s >  {max_val}LL) s =  {max_val}LL;\n'
-                    newline += f'{indent}    if (s < {min_val}LL) s = {min_val}LL;\n'
-                    newline += f'{indent}    input[{in_offset} + i] = (in_container_t)(long long)s;\n'
-                    newline += f'{indent}}}\n'
-                    in_offset += inp.size()
-                newline += f'{indent}out_container_t output[N_OUT];\n'
+                if io_type == 'io_stream':
+                    newline += f'{indent}hls::stream<in_container_t> input_stream("input_stream");\n'
+                    in_offset = 0
+                    for inp in model_inputs:
+                        total, frac = self._var_precision(inp)
+                        scale = 1 << frac
+                        max_val = (1 << (total - 1)) - 1
+                        min_val = -(1 << (total - 1))
+                        newline += f'{indent}for(int i = 0; i < {inp.size()}; i++) {{\n'
+                        newline += f'{indent}    long long s = (long long)floor((double)in[{in_offset} + i] * {scale}LL);\n'
+                        newline += f'{indent}    if (s >  {max_val}LL) s =  {max_val}LL;\n'
+                        newline += f'{indent}    if (s < {min_val}LL) s = {min_val}LL;\n'
+                        newline += f'{indent}    input_stream.write((in_container_t)(long long)s);\n'
+                        newline += f'{indent}}}\n'
+                        in_offset += inp.size()
+                    newline += f'{indent}hls::stream<out_container_t> output_stream("output_stream");\n'
+                else:
+                    newline += f'{indent}in_container_t input[N_IN];\n'
+                    in_offset = 0
+                    for inp in model_inputs:
+                        total, frac = self._var_precision(inp)
+                        scale = 1 << frac
+                        max_val = (1 << (total - 1)) - 1
+                        min_val = -(1 << (total - 1))
+                        newline += f'{indent}for(int i = 0; i < {inp.size()}; i++) {{\n'
+                        newline += f'{indent}    long long s = (long long)floor((double)in[{in_offset} + i] * {scale}LL);\n'
+                        newline += f'{indent}    if (s >  {max_val}LL) s =  {max_val}LL;\n'
+                        newline += f'{indent}    if (s < {min_val}LL) s = {min_val}LL;\n'
+                        newline += f'{indent}    input[{in_offset} + i] = (in_container_t)(long long)s;\n'
+                        newline += f'{indent}}}\n'
+                        in_offset += inp.size()
+                    newline += f'{indent}out_container_t output[N_OUT];\n'
 
             elif '// hls-fpga-machine-learning insert float-zero' in line:
                 newline = line
-                # `in_container_t input[N_IN] = {};` trips ac_int's explicit
-                # default constructor under clang; zero the array explicitly.
-                newline += f'{indent}in_container_t input[N_IN];\n'
-                newline += f'{indent}for(int i = 0; i < N_IN; i++) input[i] = (in_container_t)0;\n'
-                newline += f'{indent}out_container_t output[N_OUT];\n'
+                if io_type == 'io_stream':
+                    newline += f'{indent}hls::stream<in_container_t> input_stream("input_stream");\n'
+                    newline += f'{indent}for(int i = 0; i < N_IN; i++) input_stream.write((in_container_t)0);\n'
+                    newline += f'{indent}hls::stream<out_container_t> output_stream("output_stream");\n'
+                else:
+                    # `in_container_t input[N_IN] = {};` trips ac_int's explicit
+                    # default constructor under clang; zero the array explicitly.
+                    newline += f'{indent}in_container_t input[N_IN];\n'
+                    newline += f'{indent}for(int i = 0; i < N_IN; i++) input[i] = (in_container_t)0;\n'
+                    newline += f'{indent}out_container_t output[N_OUT];\n'
 
             elif '// hls-fpga-machine-learning insert float-top-level-function' in line:
                 newline = line
-                newline += '#ifdef  __BAMBU__\n'
-                newline += f'{indent}m_param_alloc(0, sizeof(input));\n'
-                newline += f'{indent}m_param_alloc(1, sizeof(output));\n'
-                newline += '#endif\n'
-                newline += f'{indent}{proj}_float(input, output);\n'
+                if io_type == 'io_stream':
+                    newline += '#ifdef  __BAMBU__\n'
+                    newline += f'{indent}m_param_alloc(0, sizeof(input_stream));\n'
+                    newline += f'{indent}m_param_alloc(1, sizeof(output_stream));\n'
+                    newline += '#endif\n'
+                    newline += f'{indent}{proj}_float(input_stream, output_stream);\n'
+                else:
+                    newline += '#ifdef  __BAMBU__\n'
+                    newline += f'{indent}m_param_alloc(0, sizeof(input));\n'
+                    newline += f'{indent}m_param_alloc(1, sizeof(output));\n'
+                    newline += '#endif\n'
+                    newline += f'{indent}{proj}_float(input, output);\n'
 
             elif '// hls-fpga-machine-learning insert float-tb-output' in line:
                 newline = line
@@ -246,10 +357,17 @@ class BambuAcceleratorWriter(BambuWriter):
                 for out in model_outputs:
                     total, frac = self._var_precision(out)
                     scale = 1 << frac
-                    newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
-                    newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
-                    newline += f'{indent}    fout << (double)raw / {scale}.0 << " ";\n'
-                    newline += f'{indent}}}\n'
+                    if io_type == 'io_stream':
+                        newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                        newline += f'{indent}    out_container_t raw_i = output_stream.read();\n'
+                        newline += f'{indent}    long long raw = ((long long)raw_i.to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                        newline += f'{indent}    fout << (double)raw / {scale}.0 << " ";\n'
+                        newline += f'{indent}}}\n'
+                    else:
+                        newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                        newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                        newline += f'{indent}    fout << (double)raw / {scale}.0 << " ";\n'
+                        newline += f'{indent}}}\n'
                     out_offset += out.size()
                 newline += f'{indent}fout << "\\n";\n'
 
@@ -259,10 +377,17 @@ class BambuAcceleratorWriter(BambuWriter):
                 for out in model_outputs:
                     total, frac = self._var_precision(out)
                     scale = 1 << frac
-                    newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
-                    newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
-                    newline += f'{indent}    std::cout << (double)raw / {scale}.0 << " ";\n'
-                    newline += f'{indent}}}\n'
+                    if io_type == 'io_stream':
+                        newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                        newline += f'{indent}    out_container_t raw_i = output_stream.read();\n'
+                        newline += f'{indent}    long long raw = ((long long)raw_i.to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                        newline += f'{indent}    std::cout << (double)raw / {scale}.0 << " ";\n'
+                        newline += f'{indent}}}\n'
+                    else:
+                        newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                        newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                        newline += f'{indent}    std::cout << (double)raw / {scale}.0 << " ";\n'
+                        newline += f'{indent}}}\n'
                     out_offset += out.size()
                 newline += f'{indent}std::cout << std::endl;\n'
 

--- a/hls4ml/writer/bambu_accelerator_writer.py
+++ b/hls4ml/writer/bambu_accelerator_writer.py
@@ -1,0 +1,308 @@
+import os
+import stat
+from pathlib import Path
+
+from hls4ml.writer.bambu_writer import BambuWriter
+
+
+class BambuAcceleratorWriter(BambuWriter):
+    """Extends BambuWriter with an integer-container wrapper around the ap_fixed HLS core.
+
+    Each input/output element is packed into the smallest standard unsigned integer
+    (8/16/32/64-bit) that fits the fixed-point width, keeping the AXI bus aligned
+    to 128 bits without introducing any IEEE 754 hardware.
+
+    This commit lands io_parallel only (a flat C-array interface). The wrapper
+    inlines the layer pipeline directly — it does NOT call `myproject()` from
+    the core. Inlining is what lets the same wrapper structure work for
+    io_stream too (next commit) where Bambu's DATAFLOW scheduler can't bind
+    sub-function array-pointer parameters correctly. For symmetry we use the
+    same wrapper layout for io_parallel.
+    """
+
+    # The wrapper myproject_float owns the top-level interface. The inner
+    # myproject becomes a sub-function (its definition is still emitted but
+    # unused on the BambuAccelerator path) and must NOT emit its own
+    # `#pragma HLS interface` lines — Bambu's InterfaceInfer rejects two
+    # competing declarations on the same port.
+    _emit_core_interface_pragmas = False
+
+    @staticmethod
+    def _container_width(precision_width):
+        """Smallest power-of-2 width (8/16/32/64) that fits precision_width bits."""
+        if precision_width <= 8:
+            return 8
+        if precision_width <= 16:
+            return 16
+        if precision_width <= 32:
+            return 32
+        return 64
+
+    @staticmethod
+    def _var_precision(v):
+        """Return (total_bits, frac_bits) for a model variable."""
+        try:
+            total = v.type.precision.width
+            integer = v.type.precision.integer
+            return total, total - integer
+        except AttributeError:
+            return 32, 0
+
+    def _max_container_width(self, variables):
+        """Return the container width needed for the widest variable in the list."""
+        max_w = max((self._var_precision(v)[0] for v in variables), default=32)
+        return self._container_width(max_w)
+
+    def _compute_io_sizes(self, model):
+        """Return total flattened input and output sizes (Python ints)."""
+        n_in = sum(v.size() for v in model.get_input_variables())
+        n_out = sum(v.size() for v in model.get_output_variables())
+        return n_in, n_out
+
+    def write_float_header(self, model):
+        """Write firmware/<proj>_float.h"""
+        filedir = os.path.dirname(os.path.abspath(__file__))
+        proj = model.config.get_project_name()
+
+        n_in, n_out = self._compute_io_sizes(model)
+        in_cw = self._max_container_width(model.get_input_variables())
+        out_cw = self._max_container_width(model.get_output_variables())
+
+        tmpl = open(os.path.join(filedir, '../templates/bambu/firmware/myproject_float.h'))
+        fout = open(f'{model.config.get_output_dir()}/firmware/{proj}_float.h', 'w')
+
+        for line in tmpl.readlines():
+            if 'MYPROJECT' in line:
+                line = line.replace('MYPROJECT', proj.upper())
+            if 'myproject' in line:
+                line = line.replace('myproject', proj)
+
+            if '// hls-fpga-machine-learning insert float-includes' in line:
+                newline = line
+
+            elif '// hls-fpga-machine-learning insert definitions' in line:
+                newline = line
+                newline += f'#define IN_CONTAINER_WIDTH  {in_cw}\n'
+                newline += f'#define OUT_CONTAINER_WIDTH {out_cw}\n'
+                newline += f'typedef ac_int<IN_CONTAINER_WIDTH,  false> in_container_t;\n'
+                newline += f'typedef ac_int<OUT_CONTAINER_WIDTH, false> out_container_t;\n'
+                newline += f'static const unsigned N_IN  = {n_in};\n'
+                newline += f'static const unsigned N_OUT = {n_out};\n'
+
+            elif '// hls-fpga-machine-learning insert float-signature' in line:
+                newline = line
+                newline += f'void {proj}_float(in_container_t input[N_IN], out_container_t output[N_OUT]);\n'
+
+            else:
+                newline = line
+
+            fout.write(newline)
+
+        tmpl.close()
+        fout.close()
+
+    # Wrapper-side emission helpers. The accelerator owns the
+    # container-packing layer and composes with the layer-pipeline helpers
+    # inherited from BambuWriter (`_emit_core_*`, `_emit_load_weights_block`,
+    # `_emit_internal_stream_decls`, `_emit_layer_calls`).
+
+    def _emit_ingest_helper(self, inp):
+        """Static decode function: container -> core input variable."""
+        total, _ = self._var_precision(inp)
+        return (
+            f'static void ingest_{inp.name}('
+            f'in_container_t input[N_IN], '
+            f'{inp.type.name} {inp.name}[{inp.size()}]) {{\n'
+            f'    #pragma clang loop unroll(full)\n'
+            f'    for (int i = 0; i < {inp.size()}; i++)\n'
+            f'        {inp.name}[i].set_slc(0, input[i].slc<{total}>(0));\n'
+            f'}}\n\n'
+        )
+
+    def _emit_egress_helper(self, out_var):
+        """Static encode function: core output variable -> container."""
+        total, _ = self._var_precision(out_var)
+        return (
+            f'static void egress_{out_var.name}('
+            f'{out_var.type.name} {out_var.name}[{out_var.size()}], '
+            f'out_container_t output[N_OUT]) {{\n'
+            f'    #pragma clang loop unroll(full)\n'
+            f'    for (int i = 0; i < {out_var.size()}; i++) {{\n'
+            f'        output[i] = 0;\n'
+            f'        output[i].set_slc(0, {out_var.name}[i].slc<{total}>(0));\n'
+            f'    }}\n'
+            f'}}\n\n'
+        )
+
+    def _emit_ingest_helpers(self, model):
+        return ''.join(self._emit_ingest_helper(inp) for inp in model.get_input_variables())
+
+    def _emit_egress_helpers(self, model):
+        return ''.join(self._emit_egress_helper(o) for o in model.get_output_variables())
+
+    def _emit_ingest_calls(self, model, indent='    '):
+        return ''.join(f'{indent}ingest_{inp.name}(input, {inp.name});\n' for inp in model.get_input_variables())
+
+    def _emit_egress_calls(self, model, indent='    '):
+        return ''.join(f'{indent}egress_{o.name}({o.name}, output);\n' for o in model.get_output_variables())
+
+    def _emit_wrapper_signature(self, proj):
+        return f'void {proj}_float(in_container_t input[N_IN], out_container_t output[N_OUT])\n'
+
+    def write_float_wrapper(self, model):
+        """Write firmware/<proj>_float.cpp — ingest/egress helpers wrapping
+        the inlined layer pipeline."""
+        proj = model.config.get_project_name()
+        indent = '    '
+
+        # Bambu DATAFLOW (when active for io_stream) requires every local
+        # stream to be declared before any sub-function call; declarations
+        # first, then calls in pipeline order. The same layout works for
+        # io_parallel.
+        parts = [
+            f'#include "{proj}_float.h"\n',
+            f'#include "{proj}.h"\n',
+            '#include "parameters.h"\n',
+            '\n',
+            self._emit_ingest_helpers(model),
+            self._emit_egress_helpers(model),
+            self._emit_wrapper_signature(proj),
+            '{\n',
+            self._emit_core_io_pragma(model, indent=indent),
+            self._emit_core_input_declarations(model, indent=indent),
+            self._emit_core_output_declarations(model, indent=indent),
+            self._emit_internal_stream_decls(model, indent=indent),
+            self._emit_ingest_calls(model, indent=indent),
+            self._emit_load_weights_block(model, indent=indent),
+            # `_emit_load_weights_block` ends with `#endif` (no trailing
+            # newline — kept byte-faithful to BambuBackend's existing
+            # emission, where the next template line is blank and provides
+            # the separator). Composing strings here, we add the newline
+            # explicitly so the `nnet::dense(...)` call below isn't gobbled
+            # as garbage at end of #endif.
+            '\n' if model.config.get_writer_config()['WriteWeightsTxt'] else '',
+            self._emit_layer_calls(model, indent=indent),
+            self._emit_egress_calls(model, indent=indent),
+            '}\n',
+        ]
+
+        with open(f'{model.config.get_output_dir()}/firmware/{proj}_float.cpp', 'w') as fout:
+            fout.write(''.join(parts))
+
+    def write_float_test_bench(self, model):
+        """Write <proj>_float_test.cpp"""
+        filedir = os.path.dirname(os.path.abspath(__file__))
+        proj = model.config.get_project_name()
+
+        model_inputs = model.get_input_variables()
+        model_outputs = model.get_output_variables()
+
+        tmpl = open(os.path.join(filedir, '../templates/bambu/myproject_float_test.cpp'))
+        fout = open(f'{model.config.get_output_dir()}/{proj}_float_test.cpp', 'w')
+
+        for line in tmpl.readlines():
+            indent = ' ' * (len(line) - len(line.lstrip(' ')))
+
+            if 'myproject' in line and '// hls-fpga-machine-learning' not in line:
+                newline = line.replace('myproject', proj)
+
+            elif '// hls-fpga-machine-learning insert float-data' in line:
+                newline = line
+                newline += f'{indent}in_container_t input[N_IN];\n'
+                in_offset = 0
+                for inp in model_inputs:
+                    total, frac = self._var_precision(inp)
+                    scale = 1 << frac
+                    max_val = (1 << (total - 1)) - 1
+                    min_val = -(1 << (total - 1))
+                    newline += f'{indent}for(int i = 0; i < {inp.size()}; i++) {{\n'
+                    newline += f'{indent}    long long s = (long long)floor((double)in[{in_offset} + i] * {scale}LL);\n'
+                    newline += f'{indent}    if (s >  {max_val}LL) s =  {max_val}LL;\n'
+                    newline += f'{indent}    if (s < {min_val}LL) s = {min_val}LL;\n'
+                    newline += f'{indent}    input[{in_offset} + i] = (in_container_t)(long long)s;\n'
+                    newline += f'{indent}}}\n'
+                    in_offset += inp.size()
+                newline += f'{indent}out_container_t output[N_OUT];\n'
+
+            elif '// hls-fpga-machine-learning insert float-zero' in line:
+                newline = line
+                # `in_container_t input[N_IN] = {};` trips ac_int's explicit
+                # default constructor under clang; zero the array explicitly.
+                newline += f'{indent}in_container_t input[N_IN];\n'
+                newline += f'{indent}for(int i = 0; i < N_IN; i++) input[i] = (in_container_t)0;\n'
+                newline += f'{indent}out_container_t output[N_OUT];\n'
+
+            elif '// hls-fpga-machine-learning insert float-top-level-function' in line:
+                newline = line
+                newline += '#ifdef  __BAMBU__\n'
+                newline += f'{indent}m_param_alloc(0, sizeof(input));\n'
+                newline += f'{indent}m_param_alloc(1, sizeof(output));\n'
+                newline += '#endif\n'
+                newline += f'{indent}{proj}_float(input, output);\n'
+
+            elif '// hls-fpga-machine-learning insert float-tb-output' in line:
+                newline = line
+                out_offset = 0
+                for out in model_outputs:
+                    total, frac = self._var_precision(out)
+                    scale = 1 << frac
+                    newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                    newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                    newline += f'{indent}    fout << (double)raw / {scale}.0 << " ";\n'
+                    newline += f'{indent}}}\n'
+                    out_offset += out.size()
+                newline += f'{indent}fout << "\\n";\n'
+
+            elif '// hls-fpga-machine-learning insert float-output' in line:
+                newline = line
+                out_offset = 0
+                for out in model_outputs:
+                    total, frac = self._var_precision(out)
+                    scale = 1 << frac
+                    newline += f'{indent}for(int i = 0; i < {out.size()}; i++) {{\n'
+                    newline += f'{indent}    long long raw = ((long long)output[{out_offset} + i].to_uint64() << (64 - {total})) >> (64 - {total});\n'
+                    newline += f'{indent}    std::cout << (double)raw / {scale}.0 << " ";\n'
+                    newline += f'{indent}}}\n'
+                    out_offset += out.size()
+                newline += f'{indent}std::cout << std::endl;\n'
+
+            else:
+                newline = line
+
+            fout.write(newline)
+
+        tmpl.close()
+        fout.close()
+
+    def write_float_build_scripts(self, model):
+        """Write build_tb_float_exe.sh and overwrite build_lib.sh with float-aware version."""
+        filedir = Path(__file__).parent
+
+        # build_tb_float_exe.sh
+        tb_float_src = (filedir / '../templates/bambu/build_tb_float_exe.sh').resolve()
+        tb_float_dst = Path(f'{model.config.get_output_dir()}/build_tb_float_exe.sh').resolve()
+        with open(tb_float_src) as src, open(tb_float_dst, 'w') as dst:
+            for line in src.readlines():
+                line = line.replace('myproject', model.config.get_project_name())
+                line = line.replace('mystamp', model.config.get_config_value('Stamp'))
+                dst.write(line)
+        tb_float_dst.chmod(tb_float_dst.stat().st_mode | stat.S_IEXEC)
+
+        # Overwrite build_lib.sh with float-aware version that links both
+        # myproject.o and myproject_float.o into the bridge .so.
+        build_lib_float_src = (filedir / '../templates/bambu/build_lib_float.sh').resolve()
+        build_lib_dst = Path(f'{model.config.get_output_dir()}/build_lib.sh').resolve()
+        with open(build_lib_float_src) as src, open(build_lib_dst, 'w') as dst:
+            for line in src.readlines():
+                line = line.replace('myproject', model.config.get_project_name())
+                line = line.replace('mystamp', model.config.get_config_value('Stamp'))
+                dst.write(line)
+        build_lib_dst.chmod(build_lib_dst.stat().st_mode | stat.S_IEXEC)
+
+    def write_hls(self, model, is_multigraph=False):
+        super().write_hls(model, is_multigraph=is_multigraph)
+        if not is_multigraph:
+            self.write_float_header(model)
+            self.write_float_wrapper(model)
+            self.write_float_test_bench(model)
+            self.write_float_build_scripts(model)

--- a/hls4ml/writer/bambu_writer.py
+++ b/hls4ml/writer/bambu_writer.py
@@ -121,6 +121,109 @@ class BambuWriter(Writer):
         elif mode == 'stream':
             return f'//#pragma HLS STREAM variable={variable.name} depth={depth}'
 
+    # Helpers reused by `write_project_cpp` and (in a forthcoming subclass)
+    # by a wrapper writer that emits a different top-level function around
+    # this core. The first three are consumed below; the last three
+    # (`_emit_core_*`) are forward-looking infrastructure for the wrapper.
+
+    def _emit_load_weights_block(self, model, indent='    '):
+        """Emit the `#ifndef __BAMBU__` weight-loading block; '' if disabled."""
+        if not model.config.get_writer_config()['WriteWeightsTxt']:
+            return ''
+        out = '#ifndef __BAMBU__\n'
+        out += f'{indent}static bool loaded_weights = false;\n'
+        out += f'{indent}if (!loaded_weights) {{\n'
+        for layer in model.get_layers():
+            for w in layer.get_weights():
+                if w.weight_class == 'CompressedWeightVariable':
+                    out += indent + '    nnet::load_compressed_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
+                        w.type.name, w.nonzeros, w.name, w.name
+                    )
+                elif w.weight_class == 'ExponentWeightVariable':
+                    out += indent + '    nnet::load_exponent_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
+                        w.type.name, w.data_length, w.name, w.name
+                    )
+                else:
+                    out += indent + '    nnet::load_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
+                        w.type.name, w.data_length, w.name, w.name
+                    )
+        out += '        loaded_weights = true;'
+        out += '    }\n'
+        out += '#endif'
+        return out
+
+    def _emit_internal_stream_decls(self, model, indent='    '):
+        """Emit declarations for every non-input/output per-layer variable.
+
+        Bambu's DATAFLOW requires every local stream to be declared before
+        any sub-function call in the top-function body, so they live in the
+        same block as the layer calls.
+        """
+        model_inputs = model.get_input_variables()
+        model_outputs = model.get_output_variables()
+        out = ''
+        for layer in model.get_layers():
+            for var in layer.get_variables():
+                if var in model_inputs or var in model_outputs:
+                    continue
+                def_cpp = var.definition_cpp()
+                if def_cpp is None:
+                    continue
+                out += f'{indent}{def_cpp};\n'
+                if var.pragma:
+                    out += f'{indent}{self._make_array_pragma(var)}\n\n'
+        return out
+
+    def _emit_layer_calls(self, model, indent='    '):
+        """Emit the per-layer `function_cpp` calls."""
+        out = ''
+        for layer in model.get_layers():
+            func = layer.get_attr('function_cpp', None)
+            if not func:
+                continue
+            if not isinstance(func, (list, set)):
+                func = [func]
+            if len(func) == 1:
+                out += f'{indent}{func[0]} // {layer.name}\n'
+            else:
+                out += f'{indent}// {layer.name}\n'
+                for entry in func:
+                    out += f'{indent}{entry}\n'
+            if model.config.trace_output and layer.get_attr('trace', False):
+                out += '#ifndef __SYNTHESIS__\n'
+                for var in layer.get_variables():
+                    out += '{}nnet::save_layer_output<{}>({}, "{}", {});\n'.format(
+                        indent, var.type.name, var.name, layer.name, var.size_cpp()
+                    )
+                out += '#endif\n'
+            out += '\n'
+        return out
+
+    def _emit_core_io_pragma(self, model, indent='    '):
+        """Return `#pragma HLS DATAFLOW` for io_stream, empty otherwise.
+
+        Used by a wrapper top-level that calls into this core: the wrapper's
+        DATAFLOW pragma is what makes the per-layer streams flow concurrently.
+        """
+        io_type = model.config.get_config_value('IOType')
+        if io_type != 'io_stream':
+            return ''
+        return f'{indent}#pragma HLS DATAFLOW\n'
+
+    def _emit_core_input_declarations(self, model, indent='    '):
+        """Emit local declarations for each model input variable."""
+        out = ''
+        for inp in model.get_input_variables():
+            out += f'{indent}{inp.definition_cpp()};\n'
+        return out
+
+    def _emit_core_output_declarations(self, model, indent='    '):
+        """Emit local declarations for each model output variable."""
+        out = ''
+        for o in model.get_output_variables():
+            out += f'{indent}{o.definition_cpp()};\n'
+        return out
+
     def write_project_cpp(self, model):
         """Write the main architecture source file (myproject.cpp)
 
@@ -171,36 +274,7 @@ class BambuWriter(Writer):
                     newline += '}\n'
 
             elif '// hls-fpga-machine-learning insert load weights' in line:
-                newline = line
-                if model.config.get_writer_config()['WriteWeightsTxt']:
-                    newline += '#ifndef __BAMBU__\n'
-                    newline += '    static bool loaded_weights = false;\n'
-                    newline += '    if (!loaded_weights) {\n'
-
-                    for layer in model.get_layers():
-                        for w in layer.get_weights():
-                            if w.weight_class == 'CompressedWeightVariable':
-                                newline += (
-                                    indent
-                                    + '    nnet::load_compressed_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
-                                        w.type.name, w.nonzeros, w.name, w.name
-                                    )
-                                )
-                            elif w.weight_class == 'ExponentWeightVariable':
-                                newline += (
-                                    indent
-                                    + '    nnet::load_exponent_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
-                                        w.type.name, w.data_length, w.name, w.name
-                                    )
-                                )
-                            else:
-                                newline += indent + '    nnet::load_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
-                                    w.type.name, w.data_length, w.name, w.name
-                                )
-
-                    newline += '        loaded_weights = true;'
-                    newline += '    }\n'
-                    newline += '#endif'
+                newline = line + self._emit_load_weights_block(model)
 
             # Add input/output type
             elif '// hls-fpga-machine-learning insert IO' in line:
@@ -255,35 +329,8 @@ class BambuWriter(Writer):
 
             elif '// hls-fpga-machine-learning insert layers' in line:
                 newline = line + '\n'
-                for layer in model.get_layers():
-                    vars = layer.get_variables()
-                    for var in vars:
-                        if var not in model_inputs and var not in model_outputs:
-                            def_cpp = var.definition_cpp()
-                            if def_cpp is not None:
-                                newline += '    ' + def_cpp + ';\n'
-                                if var.pragma:
-                                    newline += '    ' + self._make_array_pragma(var) + '\n\n'
-                for layer in model.get_layers():
-                    func = layer.get_attr('function_cpp', None)
-                    if func:
-                        if not isinstance(func, (list, set)):
-                            func = [func]
-                        if len(func) == 1:
-                            newline += '    ' + func[0] + ' // ' + layer.name + '\n'
-                        else:
-                            newline += '    // ' + layer.name + '\n'
-                            for line in func:
-                                newline += '    ' + line + '\n'
-                        if model.config.trace_output and layer.get_attr('trace', False):
-                            vars = layer.get_variables()
-                            newline += '#ifndef __SYNTHESIS__\n'
-                            for var in vars:
-                                newline += '    nnet::save_layer_output<{}>({}, "{}", {});\n'.format(
-                                    var.type.name, var.name, layer.name, var.size_cpp()
-                                )
-                            newline += '#endif\n'
-                        newline += '\n'
+                newline += self._emit_internal_stream_decls(model)
+                newline += self._emit_layer_calls(model)
 
             # Just copy line
             else:

--- a/hls4ml/writer/bambu_writer.py
+++ b/hls4ml/writer/bambu_writer.py
@@ -53,10 +53,17 @@ class BambuWriter(Writer):
 
         if write_txt_file:
             h_file.write('#ifndef __SYNTHESIS__\n')
-            h_file.write(var.definition_cpp() + ';\n')
+            # `static` (internal linkage) so each translation unit that
+            # includes this weight header gets its own private copy. With
+            # the BambuAccelerator wrapper inlining the layer pipeline,
+            # both myproject.cpp and myproject_float.cpp include
+            # parameters.h; without `static` they collide at link time
+            # ("multiple definition of `w2'").
+            h_file.write('static ' + var.definition_cpp() + ';\n')
             h_file.write('#else\n')
-
-        h_file.write(var.definition_cpp() + ' = {')
+            h_file.write('static const ' + var.definition_cpp() + ' = {')
+        else:
+            h_file.write(var.definition_cpp() + ' = {')
 
         # fill c++ array.
         # not including internal brackets for multidimensional case

--- a/hls4ml/writer/bambu_writer.py
+++ b/hls4ml/writer/bambu_writer.py
@@ -16,6 +16,13 @@ config_filename = 'hls4ml_config.yml'
 
 
 class BambuWriter(Writer):
+    # Whether the top-level core function should emit its own
+    # `#pragma HLS interface` lines. A subclass that wraps this core inside
+    # a different top-level (and owns the AXI/AXIS interface there) sets
+    # this to False so InterfaceInfer doesn't see two competing
+    # declarations on the same port.
+    _emit_core_interface_pragmas = True
+
     def print_array_to_cpp(self, var, odir, namespace=None, write_txt_file=True):
         """Write a weights array to C++ header files.
 
@@ -198,35 +205,50 @@ class BambuWriter(Writer):
             # Add input/output type
             elif '// hls-fpga-machine-learning insert IO' in line:
                 newline = line
-                all_inputs = [i.name for i in model_inputs]
-                all_outputs = [o.name for o in model_outputs]
                 all_brams = [b.name for b in model_brams]
                 io_type = model.config.get_config_value('IOType')
 
                 pipeline_style = model.config.pipeline_style
                 pipeline_ii = model.config.pipeline_ii
-                pipeline_pragma = indent + f'//#pragma HLS {pipeline_style.upper()}'
+                # PIPELINE stays commented out: Bambu's default II=1 isn't
+                # achievable for the layer pipeline (`Function pipelining
+                # not possible with II=1`, observed minII=2 maxII=4).
+                # DATAFLOW (io_stream) IS activated — io_stream layers need
+                # it to flow concurrently as separate tasks.
+                pragma_prefix = '//' if pipeline_style == 'pipeline' else ''
+                pipeline_pragma = indent + f'{pragma_prefix}#pragma HLS {pipeline_style.upper()}'
                 if pipeline_style == 'pipeline' and pipeline_ii is not None:
                     pipeline_pragma += f' II={pipeline_ii}\n'
                 else:
                     pipeline_pragma += '\n'
+
+                # Per-port `#pragma HLS interface` directives. Two changes
+                # vs. the old comma-list form:
+                #   - io_parallel emits NOTHING. Current Bambu rejects
+                #     `mode=valid` as "Invalid HLS interface mode"; the
+                #     valid-handshake interface is derived by
+                #     `--generate-interface=INFER` from the typed array
+                #     parameters in the function signature.
+                #   - io_stream emits one `mode=axis` line per port (Bambu
+                #     requires explicit AXIS pragmas; the comma-list form
+                #     is rejected by current InterfaceInfer).
+                # `_emit_core_interface_pragmas = False` suppresses the
+                # io_stream emission for a subclass that wraps this core
+                # in a different top-level and owns the interface there.
+                interface_pragmas = ''
+                if self._emit_core_interface_pragmas and io_type == 'io_stream':
+                    for port in [i.name for i in model_inputs] + [o.name for o in model_outputs]:
+                        interface_pragmas += f'{indent}#pragma HLS interface mode=axis port={port}\n'
 
                 if io_type == 'io_parallel':
                     for i in model_inputs:
                         newline += indent + self._make_array_pragma(i) + '\n'
                     for o in model_outputs:
                         newline += indent + self._make_array_pragma(o) + '\n'
-                    # TODO discussed adding a handle for setting the interface mode for individual input and output arrays
-                    # Probably the handle doesn't need to be exposed to the user but should be just set in hls_model.py
-                    newline += indent + '#pragma HLS interface mode=valid port={},{} \n'.format(
-                        ','.join(all_inputs), ','.join(all_outputs)
-                    )
                     newline += pipeline_pragma
 
                 if io_type == 'io_stream':
-                    newline += indent + '#pragma HLS interface mode=axis port={},{} \n'.format(
-                        ','.join(all_inputs), ','.join(all_outputs)
-                    )
+                    newline += interface_pragmas
                     if all_brams:
                         newline += indent + '//#pragma HLS INTERFACE bram port={} \n'.format(','.join(all_brams))
                     newline += pipeline_pragma

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -77,7 +77,7 @@ def test_csimulation(test_case_id, simple_model, tmp_path, io_type, strategy, gr
     assert np.allclose(bridge_result, csim_result, rtol=0.0, atol=1e-4)
 
 
-@pytest.mark.parametrize('io_type', ['io_parallel'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
 @pytest.mark.parametrize('batch_size', [10])
@@ -123,7 +123,7 @@ def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, g
     assert np.allclose(bridge_result, cosim_result, rtol=0.0, atol=1e-4)
 
 
-@pytest.mark.parametrize('io_type', ['io_parallel'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
 @pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -181,14 +181,17 @@ def test_vsynth(test_case_id, simple_model, io_type, strategy, granularity, back
         output_dir=str(vsynth_proj_dir),
         io_type=io_type,
         backend=backend,
-        part=part
+        part=part,
+        clock_period=25,
     )
     hls_model.build(csim=False, synth=True, cosim=True, vsynth=True)
 
     # Bambu-specific artifact checks
     if backend in ('Bambu', 'BambuAccelerator'):
-        # Ensure we get bambu results file
-        assert sum(1 for _ in vsynth_proj_dir.rglob("bambu_results_*.xml")) >= 1
+        # Ensure we get bambu results file. Older Bambu versions produced
+        # `bambu_results_<flow>.xml`; current versions produce
+        # `bambu_results.xml` — match both.
+        assert sum(1 for _ in vsynth_proj_dir.rglob("bambu_results*.xml")) >= 1
 
         # Ensure we get expected reports
         if hls_model.config.get_config_value('FPGAFamily') == 'Xilinx':

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -35,7 +35,7 @@ def count_files_with_extension(directory, extension):
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
 @pytest.mark.parametrize('batch_size', [10])
-@pytest.mark.parametrize('backend', ['Vitis', 'Bambu'])
+@pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])
 def test_csimulation(test_case_id, simple_model, tmp_path, io_type, strategy, granularity, batch_size, backend):
     output_dir = str(test_root_path / test_case_id)
 
@@ -81,7 +81,7 @@ def test_csimulation(test_case_id, simple_model, tmp_path, io_type, strategy, gr
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
 @pytest.mark.parametrize('batch_size', [10])
-@pytest.mark.parametrize('backend', ['Vitis', 'Bambu'])
+@pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])
 def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, granularity, batch_size, backend):
     output_dir = str(test_root_path / test_case_id)
 
@@ -126,7 +126,7 @@ def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, g
 @pytest.mark.parametrize('io_type', ['io_parallel'])
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
-@pytest.mark.parametrize('backend', ['Vitis', 'Bambu'])
+@pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])
 def test_synth(test_case_id, simple_model, io_type, strategy, granularity, backend):
     """Test that a successful synth run produces the desired artifacts (.v file)"""
     synth_proj_dir = test_root_path / test_case_id
@@ -146,11 +146,13 @@ def test_synth(test_case_id, simple_model, io_type, strategy, granularity, backe
     hls_model.build(csim=False, synth=True)
 
     # Bambu-specific artifact checks
-    if backend == 'Bambu':
-        # Ensure we get bambu results file
+    if backend in ('Bambu', 'BambuAccelerator'):
+        # Ensure we get bambu results file. The accelerator wraps the core
+        # in a `_float`-suffixed top-level, so its top-level Verilog carries
+        # that suffix.
         proj_name = hls_model.config.get_project_name()
-        assert Path(synth_proj_dir, f'{proj_name}.v').exists()
-
+        suffix = '_float' if backend == 'BambuAccelerator' else ''
+        assert Path(synth_proj_dir, f'{proj_name}{suffix}.v').exists()
 
     # TODO: Vitis-specific artifact checks
 
@@ -158,10 +160,13 @@ def test_synth(test_case_id, simple_model, io_type, strategy, granularity, backe
 @pytest.mark.parametrize('io_type', ['io_parallel'])
 @pytest.mark.parametrize('strategy', ['latency'])
 @pytest.mark.parametrize('granularity', ['name'])
-@pytest.mark.parametrize('backend', ['Vitis', 'Bambu'])
-def test_vsynth(test_case_id, simple_model, io_type, strategy, granularity, backend):
+@pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])
+@pytest.mark.parametrize('part', ['nx2h540tsc', 'xc7a100tcsg324-1'])
+def test_vsynth(test_case_id, simple_model, io_type, strategy, granularity, backend, part):
     """Test that a successful vsynth run produces the desired reports.
-    Uses 7-Series Artix part "xc7a100tcsg324-1" to synthesize in Vivado.
+    Sweeps a NanoXplore (`nx2h540tsc`) and a 7-Series Artix
+    (`xc7a100tcsg324-1`) target so the Bambu flow is exercised on both
+    target families.
     """
     vsynth_proj_dir = test_root_path / test_case_id
 
@@ -176,12 +181,12 @@ def test_vsynth(test_case_id, simple_model, io_type, strategy, granularity, back
         output_dir=str(vsynth_proj_dir),
         io_type=io_type,
         backend=backend,
-        part='xc7a100tcsg324-1'
+        part=part
     )
     hls_model.build(csim=False, synth=True, cosim=True, vsynth=True)
 
     # Bambu-specific artifact checks
-    if backend == 'Bambu':
+    if backend in ('Bambu', 'BambuAccelerator'):
         # Ensure we get bambu results file
         assert sum(1 for _ in vsynth_proj_dir.rglob("bambu_results_*.xml")) >= 1
 

--- a/test/pytest/test_build_bambu.py
+++ b/test/pytest/test_build_bambu.py
@@ -82,7 +82,8 @@ def test_csimulation(test_case_id, simple_model, tmp_path, io_type, strategy, gr
 @pytest.mark.parametrize('granularity', ['name'])
 @pytest.mark.parametrize('batch_size', [10])
 @pytest.mark.parametrize('backend', ['Vitis', 'Bambu', 'BambuAccelerator'])
-def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, granularity, batch_size, backend):
+@pytest.mark.parametrize('part', ['nx2h540tsc', 'xc7a100tcsg324-1'])
+def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, granularity, batch_size, backend, part):
     output_dir = str(test_root_path / test_case_id)
 
     model = simple_model
@@ -96,13 +97,15 @@ def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, g
         hls_config=config,
         output_dir=output_dir,
         io_type=io_type,
-        backend=backend
+        backend=backend,
+        part=part,
+        clock_period=20,
     )
     hls_model.compile()
     y_pred = hls_model.predict(X_input)
 
-    input_data_tb = str(tmp_path / 'input.npy')
-    output_data_tb = str(tmp_path / 'output.npy')
+    input_data_tb = str(os.path.join(output_dir, 'input.npy'))
+    output_data_tb = str(os.path.join(output_dir, 'output.npy'))
     np.save(input_data_tb, X_input)
     np.save(output_data_tb, y_pred)
 
@@ -113,7 +116,9 @@ def test_cosimulation(test_case_id, simple_model, tmp_path, io_type, strategy, g
         io_type=io_type,
         backend=backend,
         input_data_tb=input_data_tb,
-        output_data_tb=output_data_tb
+        output_data_tb=output_data_tb,
+        part=part,
+        clock_period=20,
     )
     hls_model_cosim.compile()
     hls_model_cosim.build(synth=True, cosim=True, log_to_stdout=True)


### PR DESCRIPTION
## Summary

This PR merges `rbcarlos/hls4ml@feature/bambu-accelerator` into `nghielme/hls4ml@bambu-accelerator-backend`.

`bambu-accelerator-backend` is already based on `bambu-backend` (with the 2026.06 reporting fix). This PR layers the `BambuAccelerator` features on top:

- New `BambuAcceleratorBackend` / `bambu_accelerator_writer.py`
- `static constexpr weights/biases` in `dense_config_template` (Bambu DATAFLOW workaround)
- 2-arg `nnet::dense()` call convention
- `const` on weight/bias parameters across all nnet templates
- New float testbench templates (`build_lib_float.sh`, `myproject_float_test.cpp`, etc.)
- Updated `test_build_bambu.py`

The reporting files (`bambu_report.py`, `test_report.py`, `bambu_results_0.xml`) already contain the correct 2026.06 versions from `bambu-accelerator-backend` and will be kept as-is during conflict resolution.

## Conflict resolution plan

See `docs/superpowers/plans/2026-06-04-hls4ml-merge-bambu-backend-plus-accelerator.md` for the full decision record.


Made with [Cursor](https://cursor.com)